### PR TITLE
Fix not validating values in EXPECT_NOTIFICATION with 1 occurence

### DIFF
--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -148,7 +148,7 @@ function EXPECT_NOTIFICATION(func,...)
         end
       end
     else
-      arguments = args[#args]
+      arguments = args
     end
     arguments["notifyId"] = module.notification_counter
     module.notification_counter = module.notification_counter + 1


### PR DESCRIPTION
table.pack() don`t packs the only one argument in the number-indexed
array and returns only that one argument. So, 1st elements of args
returns nil. Assignig of args itself solves issue of getting right
argument.

Related to: [APPLINK-17030](https://adc.luxoft.com/jira/browse/APPLINK-17030)
Cloned from: https://github.com/CustomSDL/sdl_atf/pull/86