### PR TITLE
ATF does not send mobile request with not existed rpc funtion

### DIFF
--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -115,7 +115,6 @@ function module.ExpectationsList()
       table.insert(self.pinned, e)
       e.index = #self.pinned
     else
-      --print("Ftrace - expectations Add e is not pinned")
       table.insert(self.expectations, e)
       e.index = self.expectations
     end

--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -115,6 +115,7 @@ function module.ExpectationsList()
       table.insert(self.pinned, e)
       e.index = #self.pinned
     else
+      --print("Ftrace - expectations Add e is not pinned")
       table.insert(self.expectations, e)
       e.index = self.expectations
     end

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -13,7 +13,6 @@ local FAILED = expectations.FAILED
 local module = {}
 local mt = { __index = { } }
 local wrong_function_name = "WrongFunctionName"
-mt.__index.cor_id_func_map = { }
 function mt.__index:ExpectEvent(event, name)
   local ret = Expectation(name, self.connection)
   ret.event = event
@@ -135,7 +134,8 @@ function mt.__index:Send(message)
   if message.rpcCorrelationId then
     message_correlation_id = message.rpcCorrelationId 
   else
-    message_correlation_id = correlationId
+    self.correlationId = self.correlationId + 1
+    message_correlation_id = self.correlationId
   end
   self.messageId = self.messageId + 1
   self.connection:Send(
@@ -396,6 +396,7 @@ function module.MobileSession(test, connection, regAppParams)
   res.sendHeartbeatToSDL = true
   res.answerHeartbeatFromSDL = true
   res.ignoreHeartBeatAck = false
+  res.cor_id_func_map = { }
   setmetatable(res, mt)
   return res
 end

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -132,10 +132,10 @@ function mt.__index:Send(message)
     error("MobileSession:Send: frameInfo must be specified")
   end
   local message_correlation_id
-  if not message.rpcCorrelationId then
-    message_correlation_id = correlationId
-  else
+  if message.rpcCorrelationId then
     message_correlation_id = message.rpcCorrelationId 
+  else
+    message_correlation_id = correlationId
   end
   self.messageId = self.messageId + 1
   self.connection:Send(

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -155,19 +155,16 @@ function mt.__index:Send(message)
         binaryData = message.binaryData
       }
     })
-  -- During StartSession Send called with no correllation id
-  if message_correlation_id then
-    if not self.cor_id_func_map[message_correlation_id] then
-      for fname, fid in pairs(functionId) do
-        if fid == message.rpcFunctionId then
-          self.cor_id_func_map[message_correlation_id] = fname
-          break
-        end
+  if not self.cor_id_func_map[message_correlation_id] then
+    for fname, fid in pairs(functionId) do
+      if fid == message.rpcFunctionId then
+        self.cor_id_func_map[message_correlation_id] = fname
+        break
       end
-      self.cor_id_func_map[message_correlation_id] = wrong_function_name
-    else
-      error("MobileSession:Send: message with correlationId: "..message_correlation_id.." was sent earlier by ATF")
     end
+    self.cor_id_func_map[message_correlation_id] = wrong_function_name
+  else
+    error("MobileSession:Send: message with correlationId: "..message_correlation_id.." was sent earlier by ATF")
   end
 
   xmlReporter.AddMessage("mobile_connection","Send",

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -85,6 +85,11 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
     local retval= {}
     local class_, short_name
     if (name == nil ) then return retval end
+
+    if (name == "WrongFunctionName") then
+      name = "GenericResponse"
+    end
+
     if (string.find(name, "%.")) then
       class_, short_name = name:match("([^.]+).([^.]+)")
     else

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -4,6 +4,8 @@ local hmi_types = api.init("data/HMI_API.xml", true)
 local mob_types = api.init("data/MOBILE_API.xml")
 if (not hmi_api) then hmi_api = xml.open("data/HMI_API.xml") end
 if (not mobile_api) then mobile_api = xml.open("data/MOBILE_API.xml") end
+local wrong_function_name = "WrongFunctionName"
+local genric_response = "GenericResponse"
 
 -- ToDo: Fix me. detail: APPLINK-13219
 
@@ -92,8 +94,8 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
       return retval
     end
 
-    if (name == "WrongFunctionName") then
-      name = "GenericResponse"
+    if (name == wrong_function_name) then
+      name = genric_response
     end
 
     if (string.find(name, "%.")) then

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -115,7 +115,6 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
                 tmp['type'] = string.format("%s",class_type)
               end
 
-              -- tmp['mandatory'] = (v2:attr('mandatory')) and v2:attr('mandatory') or 'true'
               tmp['mandatory'] = v2:attr('mandatory') or 'true'
               if (v2:attr('array')) then tmp['array'] = v2:attr('array') end
               if (v2:attr('minsize') and v2:attr('maxsize')) then

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -57,7 +57,7 @@ function module.json_validate(table1, table2)
         if not ok then return false,"Missing one or more fields" end
       else
         if (t2keys[k1]) then
-          if v2 == nil then return false, string.format("Missing value for: '%s'",k1) end
+          if not v2 then return false, string.format("Missing value for: '%s'",k1) end
           t2keys[k1] = nil
         else
           t2keys[k1] = v1
@@ -84,7 +84,7 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
   local function get_xml_shema_validation(doc,types,name, msg_type)
     local retval= {}
     local class_, short_name
-    if (name == nil ) then return retval end
+    if not name then return retval end
 
     if (name == "WrongFunctionName") then
       name = "GenericResponse"

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -5,7 +5,7 @@ local mob_types = api.init("data/MOBILE_API.xml")
 if (not hmi_api) then hmi_api = xml.open("data/HMI_API.xml") end
 if (not mobile_api) then mobile_api = xml.open("data/MOBILE_API.xml") end
 local wrong_function_name = "WrongFunctionName"
-local genric_response = "GenericResponse"
+local generic_response = "GenericResponse"
 
 -- ToDo: Fix me. detail: APPLINK-13219
 
@@ -95,7 +95,7 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
     end
 
     if (name == wrong_function_name) then
-      name = genric_response
+      name = generic_response
     end
 
     if (string.find(name, "%.")) then

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -54,10 +54,14 @@ function module.json_validate(table1, table2)
             break
           end
         end
-        if not ok then return false,"Missing one or more fields" end
+        if not ok
+          then return false,"Missing one or more fields"
+        end
       else
         if (t2keys[k1]) then
-          if not v2 then return false, string.format("Missing value for: '%s'",k1) end
+          if not v2 then
+            return false, string.format("Missing value for: '%s'",k1)
+          end
           t2keys[k1] = nil
         else
           t2keys[k1] = v1
@@ -84,7 +88,9 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
   local function get_xml_shema_validation(doc,types,name, msg_type)
     local retval= {}
     local class_, short_name
-    if not name then return retval end
+    if not name then
+      return retval
+    end
 
     if (name == "WrongFunctionName") then
       name = "GenericResponse"
@@ -116,7 +122,9 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
               end
 
               tmp['mandatory'] = v2:attr('mandatory') or 'true'
-              if (v2:attr('array')) then tmp['array'] = v2:attr('array') end
+              if (v2:attr('array')) then
+                tmp['array'] = v2:attr('array')
+              end
               if (v2:attr('minsize') and v2:attr('maxsize')) then
                 tmp['minsize'] = v2:attr('minsize')
                 tmp['maxsize'] = v2:attr('maxsize')

--- a/test/out/validationTest.success
+++ b/test/out/validationTest.success
@@ -2,6 +2,7 @@ validate_hmi_request:true
 validate_mobile_response:true
 validate_mobile_response:false ==> not valid type 'success': current type - 'string' ; Available - 'Boolean'
 
+validate_mobile_response with "WrongFuntionName":true
 validate_hmi_notification:true
 validate_hmi_notification:false ==> not present : requestType
 

--- a/test/validationTest.lua
+++ b/test/validationTest.lua
@@ -26,6 +26,13 @@ if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._
 _res, _err = validator.validate_mobile_response( 'Slider',{ success = 'true', resultCode = {"SUCCESS"} },true)
 if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._err) else print ("validate_mobile_response:"..tostring(_res)) end
 
+_res, _err = validator.validate_mobile_response( "WrongFunctionName", { success = false, resultCode = "INVALID_DATA", info = nil })
+if (not _res) then
+  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
+end
+
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { requestType = {"PROPRIETARY"}})
 if (not _res) then print("validate_hmi_notification:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_notification:"..tostring(_res)) end
 

--- a/test/validationTest.lua
+++ b/test/validationTest.lua
@@ -19,63 +19,63 @@ local json_mob_tbl = {success = true, resultCode = {"SUCCESS"}}
 
 local _res, _err = validator.validate_hmi_request('UI.Slider', json_hmi_tbl)
 if _res then
-  print ("validate_hmi_request:"..tostring(_res))
+  print("validate_hmi_request:"..tostring(_res))
 else
   print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_response('Slider',json_mob_tbl,true)
 if _res then
-  print ("validate_mobile_response:"..tostring(_res))
+  print("validate_mobile_response:"..tostring(_res))
 else
   print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_response( 'Slider',{ success = 'true', resultCode = {"SUCCESS"} },true)
 if _res then
-  print ("validate_mobile_response:"..tostring(_res))
+  print("validate_mobile_response:"..tostring(_res))
 else
   print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_response( "WrongFunctionName", { success = false, resultCode = "INVALID_DATA", info = nil })
 if _res then
-  print ("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
+  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
 else
   print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { requestType = {"PROPRIETARY"}})
 if _res then
-  print ("validate_hmi_notification:"..tostring(_res))
+  print("validate_hmi_notification:"..tostring(_res))
 else
   print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { urlSchema = "default", fileName = "fileName"}, true)
 if _res then
-  print ("validate_hmi_notification:"..tostring(_res))
+  print("validate_hmi_notification:"..tostring(_res))
 else
   print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_notification( "OnHMIStatus", {hmiLevel = "FULL"})
 if _res then
-  print ("validate_modile_notification:"..tostring(_res))
+  print("validate_modile_notification:"..tostring(_res))
 else
   print("validate_mobile_notification:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.json_validate(json_mob_tbl, {resultCode = {"SUCCESS"} })
 if _res then
-  print ("json_validate:"..tostring(_res))
+  print("json_validate:"..tostring(_res))
 else
   print("json_validate:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.json_validate(json_mob_tbl, { success = 'true', resultCode = {"SUCCESS"} } )
 if _res then
-  print ("json_validate:"..tostring(_res))
+  print("json_validate:"..tostring(_res))
 else
   print("json_validate:"..tostring(_res).." ==> ".._err)
 end
@@ -89,7 +89,7 @@ local _res, _err = validator.validate_mobile_request('PerformInteraction',
     interactionLayout = "KEYBOARD"
   })
 if _res then
-  print ("validate_hmi_request:"..tostring(_res))
+  print("validate_hmi_request:"..tostring(_res))
 else
   print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
 end

--- a/test/validationTest.lua
+++ b/test/validationTest.lua
@@ -18,66 +18,66 @@ local json_hmi_tbl = { numTicks = 7, position = 6, sliderHeader ="sliderHeader",
 local json_mob_tbl = {success = true, resultCode = {"SUCCESS"}}
 
 local _res, _err = validator.validate_hmi_request('UI.Slider', json_hmi_tbl)
-if (not _res) then
-  print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_hmi_request:"..tostring(_res))
+else
+  print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_response('Slider',json_mob_tbl,true)
-if (not _res) then
-  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_mobile_response:"..tostring(_res))
+else
+  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_response( 'Slider',{ success = 'true', resultCode = {"SUCCESS"} },true)
-if (not _res) then
-  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_mobile_response:"..tostring(_res))
+else
+  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_response( "WrongFunctionName", { success = false, resultCode = "INVALID_DATA", info = nil })
-if (not _res) then
-  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
+else
+  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { requestType = {"PROPRIETARY"}})
-if (not _res) then
-  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_hmi_notification:"..tostring(_res))
+else
+  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { urlSchema = "default", fileName = "fileName"}, true)
-if (not _res) then
-  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_hmi_notification:"..tostring(_res))
+else
+  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_mobile_notification( "OnHMIStatus", {hmiLevel = "FULL"})
-if (not _res) then
-  print("validate_mobile_notification:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("validate_modile_notification:"..tostring(_res))
+else
+  print("validate_mobile_notification:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.json_validate(json_mob_tbl, {resultCode = {"SUCCESS"} })
-if (not _res) then
-  print("json_validate:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("json_validate:"..tostring(_res))
+else
+  print("json_validate:"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.json_validate(json_mob_tbl, { success = 'true', resultCode = {"SUCCESS"} } )
-if (not _res) then
-  print("json_validate:"..tostring(_res).." ==> ".._err)
-else
+if _res then
   print ("json_validate:"..tostring(_res))
+else
+  print("json_validate:"..tostring(_res).." ==> ".._err)
 end
 
 local _res, _err = validator.validate_mobile_request('PerformInteraction',
@@ -88,6 +88,10 @@ local _res, _err = validator.validate_mobile_request('PerformInteraction',
     helpPrompt = {{text = "helpPrompt", type = "TEXT"}},
     interactionLayout = "KEYBOARD"
   })
-if (not _res) then print("validate_hmi_request:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_request:"..tostring(_res)) end
+if _res then
+  print ("validate_hmi_request:"..tostring(_res))
+else
+  print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
+end
 
 quit()

--- a/test/validationTest.lua
+++ b/test/validationTest.lua
@@ -18,13 +18,25 @@ local json_hmi_tbl = { numTicks = 7, position = 6, sliderHeader ="sliderHeader",
 local json_mob_tbl = {success = true, resultCode = {"SUCCESS"}}
 
 local _res, _err = validator.validate_hmi_request('UI.Slider', json_hmi_tbl)
-if (not _res) then print("validate_hmi_request:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_request:"..tostring(_res)) end
+if (not _res) then
+  print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_hmi_request:"..tostring(_res))
+end
 
 _res, _err = validator.validate_mobile_response('Slider',json_mob_tbl,true)
-if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._err) else print ("validate_mobile_response:"..tostring(_res)) end
+if (not _res) then
+  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_mobile_response:"..tostring(_res))
+end
 
 _res, _err = validator.validate_mobile_response( 'Slider',{ success = 'true', resultCode = {"SUCCESS"} },true)
-if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._err) else print ("validate_mobile_response:"..tostring(_res)) end
+if (not _res) then
+  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_mobile_response:"..tostring(_res))
+end
 
 _res, _err = validator.validate_mobile_response( "WrongFunctionName", { success = false, resultCode = "INVALID_DATA", info = nil })
 if (not _res) then
@@ -34,19 +46,39 @@ else
 end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { requestType = {"PROPRIETARY"}})
-if (not _res) then print("validate_hmi_notification:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_notification:"..tostring(_res)) end
+if (not _res) then
+  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_hmi_notification:"..tostring(_res))
+end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { urlSchema = "default", fileName = "fileName"}, true)
-if (not _res) then print("validate_hmi_notification:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_notification:"..tostring(_res)) end
+if (not _res) then
+  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_hmi_notification:"..tostring(_res))
+end
 
 _res, _err = validator.validate_mobile_notification( "OnHMIStatus", {hmiLevel = "FULL"})
-if (not _res) then print("validate_mobile_notification:"..tostring(_res).." ==> ".._err) else print ("validate_modile_notification:"..tostring(_res)) end
+if (not _res) then
+  print("validate_mobile_notification:"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_modile_notification:"..tostring(_res))
+end
 
 _res, _err = validator.json_validate(json_mob_tbl, {resultCode = {"SUCCESS"} })
-if (not _res) then print("json_validate:"..tostring(_res).." ==> ".._err) else print ("json_validate:"..tostring(_res)) end
+if (not _res) then
+  print("json_validate:"..tostring(_res).." ==> ".._err)
+else
+  print ("json_validate:"..tostring(_res))
+end
 
 _res, _err = validator.json_validate(json_mob_tbl, { success = 'true', resultCode = {"SUCCESS"} } )
-if (not _res) then print("json_validate:"..tostring(_res).." ==> ".._err) else print ("json_validate:"..tostring(_res)) end
+if (not _res) then
+  print("json_validate:"..tostring(_res).." ==> ".._err)
+else
+  print ("json_validate:"..tostring(_res))
+end
 
 local _res, _err = validator.validate_mobile_request('PerformInteraction',
   { initialText = "initialText",


### PR DESCRIPTION
Fixed handling empty FunctionName, which leads to GenericResponse.
Fixed behavior of correlationId in mobile_session.
Updated validationTest.

Related to: [APPLINKK-17601](https://adc.luxoft.com/jira/browse/APPLINK-17601)
Cloned from: https://github.com/CustomSDL/sdl_atf/pull/80