### PR TITLE
In case of failed initialization of HMI or mobile ATF stops without SDL stopping

### DIFF
--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -123,6 +123,7 @@ local function CheckStatus()
   module.expectations_list:Clear()
   module.current_case_name = nil
   if module.current_case_mandatory and not success then
+    SDL:StopSDL()
     quit(1)
   end
   control:next()


### PR DESCRIPTION

Added StopSDL command into testbase CheckStatus() method
to make possible correct SDL stopping in case of any critical testcase FAIL.

Related: APPLINK-15424