### PR TITLE
ATF does not validate values in EXPECT_NOTIFICATION with one occurence

### DIFF
--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -148,7 +148,7 @@ function EXPECT_NOTIFICATION(func,...)
         end
       end
     else
-      arguments = args[#args]
+      arguments = args
     end
     arguments["notifyId"] = module.notification_counter
     module.notification_counter = module.notification_counter + 1

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -94,17 +94,22 @@ function mt.__index:ExpectAny()
   self.exp_list:Add(ret)
   return ret
 end
-function mt.__index:ExpectNotification(funcName, args)
+function mt.__index:ExpectNotification(funcName, ...)
   local event = events.Event()
   event.matches = function(_, data)
     return data.rpcFunctionId == functionId[funcName] and
     data.sessionId == self.sessionId
   end
+  args = table.pack(...)
+  if #args[1] > 0 or args[1].n == 0 then
+    args = args[1]
+  end
+
   local ret = Expectation(funcName .. " notification", self.connection)
   if #args > 0 then
-   local notify_id = args.notifyId
-   args= table.removeKey(args,'notifyId')
-   ret:ValidIf(function(self, data)
+    local notify_id = args.notifyId
+    args = table.removeKey(args,'notifyId')
+    ret:ValidIf(function(self, data)
         local arguments
         if self.occurences > #args then
           arguments = args[#args]
@@ -114,9 +119,11 @@ function mt.__index:ExpectNotification(funcName, args)
         xmlReporter.AddMessage("EXPECT_NOTIFICATION",{["Id"] = notify_id, ["name"] = tostring(funcName),["Type"]= "EXPECTED_RESULT"}, arguments)
         xmlReporter.AddMessage("EXPECT_NOTIFICATION",{["Id"] = notify_id, ["name"] = tostring(funcName),["Type"]= "AVALIABLE_RESULT"}, data.payload)
         local _res, _err = validator.validate_mobile_notification(funcName, arguments)
-        if (not _res) then return _res,_err end
+        if (not _res) then
+          return _res,_err
+        end
         return compareValues(arguments, data.payload, "payload")
-      end)
+    end)
   end
   ret.event = event
   event_dispatcher:AddEvent(self.connection, event, ret)

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -102,14 +102,12 @@ function mt.__index:ExpectNotification(funcName, ...)
   end
   args = table.pack(...)
 
-  if #args ~= 0 then
-    if #args[1] > 0 or args[1].n == 0 then
-      -- These conditions need to validate expectations received from EXPECT_NOTIFICATION
-      -- First condition - to put out array with expectations which already packed in table
-      -- Second condition - to put out expectation without parameters
-      -- Only args[1].n == 0 allow to validate notifications without parameters from EXPECT_NOTIFICATION
-      args = args[1]
-    end
+  if #args ~= 0 and (#args[1] > 0 or args[1].n == 0) then
+    -- These conditions need to validate expectations received from EXPECT_NOTIFICATION
+    -- Second condition - to put out array with expectations which already packed in table
+    -- Third condition - to put out expectation without parameters
+    -- Only args[1].n == 0 allow to validate notifications without parameters from EXPECT_NOTIFICATION
+    args = args[1]
   end
 
   local ret = Expectation(funcName .. " notification", self.connection)

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -101,8 +101,15 @@ function mt.__index:ExpectNotification(funcName, ...)
     data.sessionId == self.sessionId
   end
   args = table.pack(...)
-  if #args[1] > 0 or args[1].n == 0 then
-    args = args[1]
+
+  if #args ~= 0 then
+    if #args[1] > 0 or args[1].n == 0 then
+      -- These conditions need to validate expectations received from EXPECT_NOTIFICATION
+      -- First condition - to put out array with expectations which already packed in table
+      -- Second condition - to put out expectation without parameters
+      -- Only args[1].n == 0 allow to validate notifications without parameters from EXPECT_NOTIFICATION
+      args = args[1]
+    end
   end
 
   local ret = Expectation(funcName .. " notification", self.connection)


### PR DESCRIPTION
Fixed handling of one expectation in connecttest.EXPECT_NOTIFICATION.
mobile_session.ExpectNotification changed to allow validate notifications from another mobile sessions.

Related to: [APPLINK-17030](https://adc.luxoft.com/jira/browse/APPLINK-17030)

@AByzhynar @VVeremjova @malirod please review.