### PR TITLE
ATF does not send mobile request with not existed RPC funtion

### DIFF
--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -56,10 +56,14 @@ function module.json_validate(table1, table2)
             break
           end
         end
-        if not ok then return false,"Missing one or more fields" end
+        if not ok
+          then return false,"Missing one or more fields"
+        end
       else
         if (t2keys[k1]) then
-          if v2 == nil then return false, string.format("Missing value for: '%s'",k1) end
+          if not v2 then
+            return false, string.format("Missing value for: '%s'",k1)
+          end
           t2keys[k1] = nil
         else
           t2keys[k1] = v1
@@ -86,7 +90,9 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
   local function get_xml_shema_validation(doc,types,name, msg_type)
     local retval= {}
     local class_, short_name
-    if (name == nil ) then return retval end
+    if not name then
+      return retval
+    end
 
     if (name == wrong_function_name) then
       name = generic_response
@@ -117,9 +123,10 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
                 tmp['type'] = string.format("%s",class_type)
               end
 
-              -- tmp['mandatory'] = (v2:attr('mandatory')) and v2:attr('mandatory') or 'true'
               tmp['mandatory'] = v2:attr('mandatory') or 'true'
-              if (v2:attr('array')) then tmp['array'] = v2:attr('array') end
+              if (v2:attr('array')) then
+                tmp['array'] = v2:attr('array')
+              end
               if (v2:attr('minsize') and v2:attr('maxsize')) then
                 tmp['minsize'] = v2:attr('minsize')
                 tmp['maxsize'] = v2:attr('maxsize')

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -4,6 +4,8 @@ local hmi_types = api.init("data/HMI_API.xml", true)
 local mob_types = api.init("data/MOBILE_API.xml")
 if (not hmi_api) then hmi_api = xml.open("data/HMI_API.xml") end
 if (not mobile_api) then mobile_api = xml.open("data/MOBILE_API.xml") end
+local wrong_function_name = "WrongFunctionName"
+local generic_response = "GenericResponse"
 
 -- ToDo: Fix me. detail: APPLINK-13219
 
@@ -85,6 +87,11 @@ local function compare(schema, function_id, msgType, user_data, mandatory_check)
     local retval= {}
     local class_, short_name
     if (name == nil ) then return retval end
+
+    if (name == wrong_function_name) then
+      name = generic_response
+    end
+
     if (string.find(name, "%.")) then
       class_, short_name = name:match("([^.]+).([^.]+)")
     else

--- a/test/out/validationTest.success
+++ b/test/out/validationTest.success
@@ -2,6 +2,7 @@ validate_hmi_request:true
 validate_mobile_response:true
 validate_mobile_response:false ==> not valid type 'success': current type - 'string' ; Available - 'Boolean'
 
+validate_mobile_response with "WrongFuntionName":true
 validate_hmi_notification:true
 validate_hmi_notification:false ==> not present : requestType
 

--- a/test/validationTest.lua
+++ b/test/validationTest.lua
@@ -18,35 +18,67 @@ local json_hmi_tbl = { numTicks = 7, position = 6, sliderHeader ="sliderHeader",
 local json_mob_tbl = {success = true, resultCode = {"SUCCESS"}}
 
 local _res, _err = validator.validate_hmi_request('UI.Slider', json_hmi_tbl)
-if (not _res) then print("validate_hmi_request:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_request:"..tostring(_res)) end
+if _res then
+  print("validate_hmi_request:"..tostring(_res))
+else
+  print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.validate_mobile_response('Slider',json_mob_tbl,true)
-if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._err) else print ("validate_mobile_response:"..tostring(_res)) end
+if _res then
+  print("validate_mobile_response:"..tostring(_res))
+else
+  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.validate_mobile_response( 'Slider',{ success = 'true', resultCode = {"SUCCESS"} },true)
-if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._err) else print ("validate_mobile_response:"..tostring(_res)) end
+if _res then
+  print("validate_mobile_response:"..tostring(_res))
+else
+  print("validate_mobile_response:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.validate_mobile_response( "WrongFunctionName", { success = false, resultCode = "INVALID_DATA", info = nil })
-if (not _res) then
-  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
+if _res then
+  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
 else
-  print ("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
+  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
 end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { requestType = {"PROPRIETARY"}})
-if (not _res) then print("validate_hmi_notification:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_notification:"..tostring(_res)) end
+if _res then
+  print("validate_hmi_notification:"..tostring(_res))
+else
+  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { urlSchema = "default", fileName = "fileName"}, true)
-if (not _res) then print("validate_hmi_notification:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_notification:"..tostring(_res)) end
+if _res then
+  print("validate_hmi_notification:"..tostring(_res))
+else
+  print("validate_hmi_notification:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.validate_mobile_notification( "OnHMIStatus", {hmiLevel = "FULL"})
-if (not _res) then print("validate_mobile_notification:"..tostring(_res).." ==> ".._err) else print ("validate_modile_notification:"..tostring(_res)) end
+if _res then
+  print("validate_modile_notification:"..tostring(_res))
+else
+  print("validate_mobile_notification:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.json_validate(json_mob_tbl, {resultCode = {"SUCCESS"} })
-if (not _res) then print("json_validate:"..tostring(_res).." ==> ".._err) else print ("json_validate:"..tostring(_res)) end
+if _res then
+  print("json_validate:"..tostring(_res))
+else
+  print("json_validate:"..tostring(_res).." ==> ".._err)
+end
 
 _res, _err = validator.json_validate(json_mob_tbl, { success = 'true', resultCode = {"SUCCESS"} } )
-if (not _res) then print("json_validate:"..tostring(_res).." ==> ".._err) else print ("json_validate:"..tostring(_res)) end
+if _res then
+  print("json_validate:"..tostring(_res))
+else
+  print("json_validate:"..tostring(_res).." ==> ".._err)
+end
 
 local _res, _err = validator.validate_mobile_request('PerformInteraction',
   { initialText = "initialText",
@@ -56,6 +88,10 @@ local _res, _err = validator.validate_mobile_request('PerformInteraction',
     helpPrompt = {{text = "helpPrompt", type = "TEXT"}},
     interactionLayout = "KEYBOARD"
   })
-if (not _res) then print("validate_hmi_request:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_request:"..tostring(_res)) end
+if _res then
+  print("validate_hmi_request:"..tostring(_res))
+else
+  print("validate_hmi_request:"..tostring(_res).." ==> ".._err)
+end
 
 quit()

--- a/test/validationTest.lua
+++ b/test/validationTest.lua
@@ -26,6 +26,13 @@ if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._
 _res, _err = validator.validate_mobile_response( 'Slider',{ success = 'true', resultCode = {"SUCCESS"} },true)
 if (not _res) then print("validate_mobile_response:"..tostring(_res).." ==> ".._err) else print ("validate_mobile_response:"..tostring(_res)) end
 
+_res, _err = validator.validate_mobile_response( "WrongFunctionName", { success = false, resultCode = "INVALID_DATA", info = nil })
+if (not _res) then
+  print("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res).." ==> ".._err)
+else
+  print ("validate_mobile_response with \"WrongFuntionName\":"..tostring(_res))
+end
+
 _res, _err = validator.validate_hmi_notification( 'BasicCommunication.OnSystemRequest', { requestType = {"PROPRIETARY"}})
 if (not _res) then print("validate_hmi_notification:"..tostring(_res).." ==> ".._err) else print ("validate_hmi_notification:"..tostring(_res)) end
 


### PR DESCRIPTION
Fixed handling empty FunctionName, which leads to GenericResponse.
Fixed behavior of CorrelationId in mobile_session.
Updated validationTest.

Related to: [APPLINKK-17601](https://adc.luxoft.com/jira/browse/APPLINK-17601)
Changes got, squashed and branch name changed from: https://github.com/smartdevicelink/sdl_atf/pull/8
