### PR TITLE
Fix validation of notifications

### DIFF
--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -105,7 +105,7 @@ function mt.__index:ExpectNotification(funcName, ...)
     return data.rpcFunctionId == functionId[funcName] and
     data.sessionId == self.sessionId
   end
-  args = table.pack(...)
+  local args = table.pack(...)
 
   if #args ~= 0 and (#args[1] > 0 or args[1].n == 0) then
     -- These conditions need to validate expectations received from EXPECT_NOTIFICATION


### PR DESCRIPTION
Now validation table is local and has correct count of data.
Relates to [APPLINK-23704](https://adc.luxoft.com/jira/browse/APPLINK-23704)

Please review @dtrunov, @OHerasym, @Kozoriz, @VProdanov  @LuxoftAKutsan 