### PR TITLE
Fix expired timeout issue

### DIFF
--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -95,7 +95,7 @@ function module.Expectation(name, connection)
     timesGE = 1, -- Times Greater or Equal
     after = { }, -- Expectations that should get complied before this one
     ts = timestamp(), -- Timestamp
-    timeout = 10000, -- Maximum allowed age
+    timeout = 10500, -- Maximum allowed age
     name = name, -- Name to display in error message if failed
     connection = connection, -- Network connection
     occurences = 0, -- Expectation complience times


### PR DESCRIPTION
### PR Changes

Add to timeout 500 ms to avoid a lot of adding timeouts in test scripts.

Related: [APPLINK-24879](https://adc.luxoft.com/jira/browse/APPLINK-24879)