### PR TITLE
Align the shown time for ATF logs, do the same as in SDL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SOURCES= lua_interpreter.cc \
 	network.cc \
 	qtdynamic.cc \
 	qtlua.cc \
+	qdatetime.cc \
 	timers.cc
 
 all: interp modules/libxml.so

--- a/atf.pro
+++ b/atf.pro
@@ -2,15 +2,19 @@ HEADERS = network.h \
           timers.h \
           qtdynamic.h \
           qtlua.h \
+          qdatetime.h \
           marshal.h \
           lua_interpreter.h
+          
 SOURCES = network.cc \
           timers.cc \
           qtdynamic.cc \
           qtlua.cc \
+          qdatetime.cc \
           marshal.cc \
           main.cc \
           lua_interpreter.cc
+          
 TARGET  = interp
 QT = core network websockets
 CONFIG += c++11 qt debug

--- a/lua_interpreter.cc
+++ b/lua_interpreter.cc
@@ -8,6 +8,7 @@
 #include "network.h"
 #include "timers.h"
 #include "qtlua.h"
+#include "qdatetime.h"
 #include <assert.h>
 #include <iostream>
 #include <stdexcept>
@@ -71,6 +72,8 @@ LuaInterpreter::LuaInterpreter(QObject *parent, const QStringList::iterator& arg
   luaL_requiref(lua_state, "os", &luaopen_os, 1);
   luaL_requiref(lua_state, "bit32", &luaopen_bit32, 1);
   luaL_requiref(lua_state, "qt", &luaopen_qt, 1);
+  luaL_requiref(lua_state, "qdatetime", &luaopen_qdatetime, 1);
+
 #line 192 "main.nw"
   // extend package.cpath
   lua_getglobal(lua_state, "package");

--- a/modules/atf_logger.lua
+++ b/modules/atf_logger.lua
@@ -1,10 +1,11 @@
 local json = require("json")
 local Logger = {}
+
 Logger.mobile_log_format = "%s(%s) [version: %s, frameType: %s, encryption: %s, serviceType: %s, frameInfo: %s, messageId: %s] : %s \n"
-Logger.hmi_log_format = "%s(%s) : %s \n"
+Logger.hmi_log_format = "%s[%s] : %s \n"
 
 function formated_time()
-  return os.date("%X")
+  return qdatetime.get_datetime("dd MM yyyy hh:mm:ss,zzz")
 end
 
 function Logger:MOBtoSDL(message)

--- a/qdatetime.cc
+++ b/qdatetime.cc
@@ -1,0 +1,20 @@
+#include "qdatetime.h"
+
+int qdatetime_get_datetime(lua_State *L) {
+  const QDateTime time(QDateTime::currentDateTime());
+  const char* const format_raw = luaL_checkstring(L, 1);
+  const QString format(format_raw);
+  const QString time_string(time.toString(format));
+  const char* const time_string_raw = qPrintable(time_string);
+  lua_pushstring(L, time_string_raw);
+  return 1;
+}
+
+int luaopen_qdatetime(lua_State *L) {
+  const luaL_Reg qdatetime_lib [] = {
+    {"get_datetime", qdatetime_get_datetime},
+    {NULL, NULL}
+  };
+  luaL_newlib(L, qdatetime_lib);
+  return 1;
+}

--- a/qdatetime.h
+++ b/qdatetime.h
@@ -1,0 +1,13 @@
+#pragma once
+
+extern "C" {
+#include <lua5.2/lua.h>
+#include <lua5.2/lualib.h>
+#include <lua5.2/lauxlib.h>
+}
+
+#include <QString>
+#include <QDateTime>
+#include <QtGlobal>
+
+int luaopen_qdatetime(lua_State *L);


### PR DESCRIPTION
It will help in future analysis of the logs.
Old time format of logging for ATF:
`HMI->SDL(20:27:43)`
Featured time format of logging for ATF
(should be the same as for SDL):
`HMI->SDL[15 08 2016 20:27:43,466]`

Related to: [APPLINK-27203](https://adc.luxoft.com/jira/browse/APPLINK-27203)

@okozlovlux, @LuxoftAKutsan, @vlantonov, @pvvasilev, @AByzhynar please review.