### PR TITLE
Fix incorrect start after SDL crash

### DIFF
--- a/StopSDL.sh
+++ b/StopSDL.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-shutdown_time=100
+shutdown_time=30
 read pid < sdl.pid
 
 function shutdown_sdl {
@@ -13,9 +13,10 @@ function shutdown_sdl {
     return 1
 }
 
+# Abort is used for getting core dump
 function kill_sdl {
     echo "Kill SDL process : "$pid
-    kill -SIGTERM $pid
+    kill -SIGABRT $pid
 }
 
 shutdown_sdl || kill_sdl

--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -10,13 +10,24 @@ SDL.STOPPED = 0
 SDL.RUNNING = 1
 SDL.CRASH = -1
 
+function sleep(n)
+  os.execute("sleep " .. tonumber(n))
+end
+
 function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)    
   sdl_logger.init_log(get_script_file_name())
   if ExitOnCrash then
     self.exitOnCrash = ExitOnCrash
   end
   local status = self:CheckStatusSDL()
-  if status == self.STOPPED then
+
+  while status == self.RUNNING do
+    sleep(1)
+    print('Waiting for SDL shutdown')
+    status = self:CheckStatusSDL()
+  end
+
+  if status == self.STOPPED  or status == self.CRASH then
     local result = os.execute ('./StartSDL.sh ' .. pathToSDL .. ' ' .. smartDeviceLinkCore)
     if result then
       local msg = "SDL started"


### PR DESCRIPTION
### PR Changes:
- Fix incorrect start after SDL crash

Related: [APPLINK-27204](https://adc.luxoft.com/jira/browse/APPLINK-27204)