### PR TITLE
Add missing tests cases names in ATF log files

### DIFF
--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -72,6 +72,7 @@ function control.runNextCase()
   if testcase then
     module.current_case_name = module.case_names[testcase]
     xmlReporter.AddCase(module.current_case_name)
+    atf_logger.LOGTestCaseStart(module.current_case_name)
     testcase(module)
   else
     if SDL.autoStarted then


### PR DESCRIPTION
ATF should store test case starting

Related to [APPLINK-27517](https://adc.luxoft.com/jira/browse/APPLINK-27517)
Please review @AGritsevich, @dtrunov, @pvvasilev, @OHerasym