### PR TITLE
Extend result codes

### DIFF
--- a/modules/atf/stdlib/argument_parser.lua
+++ b/modules/atf/stdlib/argument_parser.lua
@@ -1,6 +1,8 @@
 local std = require "atf.stdlib.std"
 local table = require "atf.stdlib.std.table"
 
+local exit_codes = require('exit_codes')
+
 local validOptList = { }
 local errors = {}
 
@@ -43,13 +45,13 @@ local function errmsg (msg)
   if msg:match ("%.$") == nil then msg = msg .. "." end
   print (prog .. ": error: " .. msg .. "\n")
   print (prog .. ": Try '" .. prog .. " --help' for help.")
-  quit(3)
+  quit(exit_codes.wrong_arg)
 end
 
 local function checkReqOpt(self, arg, val)
   if val:sub (1, 1) == "-" then
     errmsg ("Option '" .. arg .. "' requires an argument.")
-    quit(3)
+    quit(exit_codes.wrong_arg)
   else
     validOptList[self[arg].key] = val
   end

--- a/modules/atf/stdlib/argument_parser.lua
+++ b/modules/atf/stdlib/argument_parser.lua
@@ -43,13 +43,13 @@ local function errmsg (msg)
   if msg:match ("%.$") == nil then msg = msg .. "." end
   print (prog .. ": error: " .. msg .. "\n")
   print (prog .. ": Try '" .. prog .. " --help' for help.")
-  quit(2)
+  quit(3)
 end
 
 local function checkReqOpt(self, arg, val)
   if val:sub (1, 1) == "-" then
     errmsg ("Option '" .. arg .. "' requires an argument.")
-    quit(2)
+    quit(3)
   else
     validOptList[self[arg].key] = val
   end

--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -315,7 +315,7 @@ function module:runSDL()
   local result, errmsg = SDL:StartSDL(config.pathToSDL, config.SDL, config.ExitOnCrash)
   if not result then
     SDL:DeleteFile()
-    quit(1)
+    quit(exit_codes.aborted)
   end
   SDL.autoStarted = true
 end
@@ -640,7 +640,7 @@ function module:connectMobile()
   :Times(AnyNumber())
   :Do(function()
       print("Disconnected!!!")
-      quit(1)
+      quit(exit_codes.aborted)
     end)
   self.mobileConnection:Connect()
   return EXPECT_EVENT(events.connectedEvent, "Connected")

--- a/modules/exit_codes.lua
+++ b/modules/exit_codes.lua
@@ -1,0 +1,6 @@
+local exit_codes ={} 
+exit_codes.success = 0
+exit_codes.aborted = 1
+exit_codes.failed = 2
+exit_codes.wrong_arg = 3
+return exit_codes

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -157,6 +157,17 @@ end
 -- For types "string", "integer" and "float" check values are in intervals from schema 
 -- For enum value check that value are included in schema
 -- For struct call CompareStructs, where structure will be checked
+
+local function table_contains(table, element)
+  for _, value in pairs(table) do
+    if value == element then
+      return true
+    end
+  end
+  return false
+end
+
+
 function module.mt.__index:CompareType(data_elem, schemaElem, isArray, nameofParameter, name_of_structure)
   local elem1 = type(data_elem)
   if (isArray=='true') then
@@ -193,8 +204,15 @@ function module.mt.__index:CompareType(data_elem, schemaElem, isArray, nameofPar
     if(self.schema.interface[interface_name].enum[complex_elem_name][data_elem] ~= nil) then 
       return true
     end 
+    --Enum element can be sended as number, so if it includes to data elements, we will set it as acceptable
+    if elem1 == 'number' then
+      local local_enum = self.schema.interface[interface_name].enum[complex_elem_name]
+      if table_contains(local_enum, data_elem) then
+        return true
+      end
+    end
     if name_of_structure~=nil then 
-      return false, "Parameter ".. name_of_structure.."."..nameofParameter..": got "..elem1..", expected enum value: "..schemaElem 
+      return false, "Parameter ".. name_of_structure.."."..nameofParameter..": got "..elem1.." \"".. tostring(data_elem).."\", expected enum value: "..schemaElem 
     end
     return false, "Parameter ".. nameofParameter.. ": got "..elem1..", expected enum value: " ..schemaElem   
   end

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -204,7 +204,7 @@ function module.mt.__index:CompareType(data_elem, schemaElem, isArray, nameofPar
     if(self.schema.interface[interface_name].enum[complex_elem_name][data_elem] ~= nil) then 
       return true
     end 
-    --Enum element can be sended as number, so if it includes to data elements, we will set it as acceptable
+    -- Enum element can be sent as number, so if it belongs to count of data elements, we will set it as acceptable
     if elem1 == 'number' then
       local local_enum = self.schema.interface[interface_name].enum[complex_elem_name]
       if table_contains(local_enum, data_elem) then

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -212,7 +212,7 @@ function module.mt.__index:CompareType(data_elem, schemaElem, isArray, nameofPar
       end
     end
     if name_of_structure~=nil then 
-      return false, "Parameter ".. name_of_structure.."."..nameofParameter..": got "..elem1.." \"".. tostring(data_elem).."\", expected enum value: "..schemaElem 
+      return false, "Parameter ".. name_of_structure.."."..nameofParameter..": got "..elem1..", expected enum value: "..schemaElem 
     end
     return false, "Parameter ".. nameofParameter.. ": got "..elem1..", expected enum value: " ..schemaElem   
   end

--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -5,6 +5,8 @@ local console = require('console')
 local fmt = require('format')
 local SDL = require('SDL')
 
+local exit_codes = require('exit_codes')
+
 local module = { }
 
 local Expectation = expectations.Expectation
@@ -85,7 +87,7 @@ function control.runNextCase()
     print_stopscript()
     xmlReporter:finalize()
     if total_testset_result == false then
-      quit(2)
+      quit(exit_codes.failed)
     else 
       quit()
     end
@@ -133,7 +135,7 @@ local function CheckStatus()
   module.current_case_name = nil
   if module.current_case_mandatory and not success then
     SDL:StopSDL()
-    quit(1)
+    quit(exit_codes.aborted)
   end
   control:next()
 end

--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -15,6 +15,8 @@ local STOPPED = SDL.STOPPED
 local RUNNING = SDL.RUNNING
 local CRASH = SDL.CRASH
 
+local total_testset_result = true
+
 local control = qt.dynamic()
 
 local function isCapital(c)
@@ -81,8 +83,12 @@ function control.runNextCase()
     end
     module.current_case_name = nil
     print_stopscript()
-    quit()
     xmlReporter:finalize()
+    if total_testset_result == false then
+      quit(2)
+    else 
+      quit()
+    end
   end
 end
 
@@ -111,6 +117,7 @@ local function CheckStatus()
   for _, e in ipairs(module.expectations_list) do
     if e.status ~= SUCCESS then
       success = false
+      total_testset_result = false
     end
     if not e.pinned and e.connection then
       event_dispatcher:RemoveEvent(e.connection, e.event)


### PR DESCRIPTION
Now ATF gets next codes:

Code 0 - all tests in the script were executed, have "PASS" result (overall status "PASSED")
Code 1 - not all test were executed - unexpected SDL disconnect, ATF's PANIC, etc. (overall status "ABORTED")
Code 2 - all tests in the script were executed, at least one test have "FAIL" result (overall status "FAILED")
Code 3 - ATF was started with wrong arguments

Related to [APPLINK-29374](https://adc.luxoft.com/jira/browse/APPLINK-29374)