### PR TITLE
Workaround  for successfull start session

### DIFF
--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -81,9 +81,14 @@ function module.Expectation(name, connection)
     if not self.verifyData then self.verifyData = {} end
     self.verifyData[#self.verifyData + 1] = function(self, data)
       local valid, msg = func(self, data)
+
       if not valid then
         self.status = module.FAILED
         self.errorMessage["ValidIf"] = msg
+      else
+        if msg ~= nil and msg~="" then
+          self.errorMessage["WARNING"] = msg
+        end
       end
     end
     return self

--- a/modules/format.lua
+++ b/modules/format.lua
@@ -34,6 +34,17 @@ function module.PrintCaseResult(startCaseTime, caseName, success, errorMessage, 
       end
     end
   end
+  -- Print warnings
+  if success and errorMessage then
+    for k, v in pairs(errorMessage) do
+      local errmsg = " " .. k .. ": " .. v
+      if config.color then
+        print(console.setattr(errmsg, "yellow", 1))
+      else
+        print(errmsg)
+      end
+    end
+  end
   return module
 end
 return module

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -83,7 +83,13 @@ function mt.__index:ExpectResponse(cor_id, ...)
         xmlReporter.AddMessage("EXPECT_RESPONSE",{["id"] = tostring(cor_id),["name"] = tostring(func_name),["Type"]= "EXPECTED_RESULT"}, arguments)
         xmlReporter.AddMessage("EXPECT_RESPONSE",{["id"] = tostring(cor_id),["name"] = tostring(func_name),["Type"]= "AVALIABLE_RESULT"}, data.payload)
         local _res, _err = mob_schema:Validate(func_name, load_schema.response, data.payload)
+
         if (not _res) then return _res,_err end
+        -- Workaround for non-existed value in enum
+        if _err~=nil and err~="" then
+          return true, _err
+        end
+        -- Finish workaround
         return compareValues(arguments, data.payload, "payload")
       end)
   end

--- a/modules/schema_validation.lua
+++ b/modules/schema_validation.lua
@@ -209,7 +209,15 @@ function module.mt.__index:CompareType(data_elem, schemaElem, isArray, nameofPar
       local local_enum = self.schema.interface[interface_name].enum[complex_elem_name]
       if table_contains(local_enum, data_elem) then
         return true
+      else
+        -- Workaround for non-existed value in enum
+        if interface_name == "Ford Sync RAPI" then
+          local err_msg = "[WARNING]: got non-existed integer value \"".. tostring(data_elem).. "\" in enum ".. schemaElem
+          return true, err_msg
+        end
+        -- Finish workaround
       end
+
     end
     if name_of_structure~=nil then 
       return false, "Parameter ".. name_of_structure.."."..nameofParameter..": got "..elem1..", expected enum value: "..schemaElem 


### PR DESCRIPTION
Add temporary solution for ignore not existing parameters that is sent from SDL to Mobile. After this ATF won't fail in startSession().
Related to [APPLINK-29722](https://adc.luxoft.com/jira/browse/APPLINK-29722)

@AByzhynar, @dcherniev, @Kozoriz, @dtrunov, @pvvasilev, @AGritsevich