### PR TITLE
Add using of default HMI and Mobile API

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -19,10 +19,12 @@ function CopyFile(file, newfile)
 end
 
 function CopyInterface()
-  local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
-  local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
-  CopyFile(mobile_api, 'data/MOBILE_API.xml')
-  CopyFile(hmi_api, 'data/HMI_API.xml')
+  if config.pathToSDLInterfaces~="" and config.pathToSDLInterfaces~=nil then
+    local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
+    local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
+    CopyFile(mobile_api, 'data/MOBILE_API.xml')
+    CopyFile(hmi_api, 'data/HMI_API.xml') 
+  end
 end
 
 function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)    

--- a/modules/atf/util.lua
+++ b/modules/atf/util.lua
@@ -94,10 +94,14 @@ function check_required_fields()
     print("ERROR: SDL is not accessible at the specified path: "..config.pathToSDL)
     os.exit(1)
   end
-  if (not is_file_exists(config.pathToSDLInterfaces.."MOBILE_API.xml")) and 
-     (not is_file_exists(config.pathToSDLInterfaces.."/MOBILE_API.xml")) then
-    print("ERROR: XML files are not accessible at the specified path: "..config.pathToSDLInterfaces)
-    os.exit(1)
+  if config.pathToSDLInterfaces~="" and config.pathToSDLInterfaces~=nil then
+    if (not is_file_exists(config.pathToSDLInterfaces.."MOBILE_API.xml")) and 
+       (not is_file_exists(config.pathToSDLInterfaces.."/MOBILE_API.xml")) then
+      print("ERROR: XML files are not accessible at the specified path: "..config.pathToSDLInterfaces)
+      os.exit(1)
+    end
+  else 
+    print "\27[33m WARNING: Parameter pathToSDLInterfaces is not specified, default APIs are used \27[0m"
   end
 end
 


### PR DESCRIPTION
If parameter pathToSDLInterfaces in config is not specified,
Mobile_API and HMI_API from data folder will be used

Related to APPLINK-29745