### PR TITLE
Use Result enum from HMI_API instead of locally saved values

### DIFF
--- a/modules/api_loader.lua
+++ b/modules/api_loader.lua
@@ -132,8 +132,7 @@ local function LoadInterfaces( api, dest )
 end
 
 
- function module.init(path, include_parent_name)
-  module.include_parent_name = include_parent_name
+ function module.init(path)
   local result = {}
   result.interface = { }
 

--- a/modules/api_loader.lua
+++ b/modules/api_loader.lua
@@ -4,7 +4,7 @@ local module = { }
 -- Include result codes that are elements in functions from Mobile Api.
 -- Each function with paremeter resultCode that has type Result
 -- should contain types of Resultcode directly in function.
--- Other resultCodes are kept in structs  
+-- Other resultCodes are kept in structs
 local function LoadResultCodes( param )
   local resultCodes ={}
   local i = 1
@@ -16,7 +16,7 @@ local function LoadResultCodes( param )
   return resultCodes
 end
 
---Load parameteres in function. Load ResultCodes if 
+--Load parameteres in function. Load ResultCodes if
 --type of parameter is "Result"
 local function LoadParamsInFunction(param, interface)
   local name = param:attr("name")
@@ -24,17 +24,17 @@ local function LoadParamsInFunction(param, interface)
   local mandatory = param:attr("mandatory")
   local array = param:attr("array")
 
-  if mandatory == nil then 
+  if mandatory == nil then
     mandatory = true
   end
 
-  if array == nil then 
+  if array == nil then
     array = false
   end
 
   local result_codes = nil
-  if name == "resultCode" and p_type == "Result" then 
-    result_codes  = LoadResultCodes(param) 
+  if name == "resultCode" and p_type == "Result" then
+    result_codes  = LoadResultCodes(param)
   end
 
   local data = {}
@@ -61,13 +61,18 @@ end
       local i = 1
       for _,e in ipairs(s:children("element")) do
         local enum_value = e:attr("name")
+
+        local value =  e:attr("value")
+        if tonumber(value) ~= nil then
+          i = tonumber(value)
+        end
         dest.interface[first].enum[name][enum_value]=i
         i= i + 1
       end
     end
   end
  end
- 
+
  local function LoadStructs(api, dest)
    for first, v in pairs (dest.interface) do
     for _, s in ipairs(v.body:children("struct")) do
@@ -84,7 +89,7 @@ end
     end
    end
  end
- 
+
 
 local function LoadFunction( api, dest  )
   for first, v in pairs (dest.interface) do
@@ -106,7 +111,7 @@ local function LoadFunction( api, dest  )
   end
 end
 
--- Load interfaces from api. Each function, enum and struct will be 
+-- Load interfaces from api. Each function, enum and struct will be
 -- kept inside appropriate interface
 local function LoadInterfaces( api, dest )
   local interfaces = api:xpath("//interface")
@@ -131,10 +136,10 @@ end
   module.include_parent_name = include_parent_name
   local result = {}
   result.interface = { }
- 
+
   local _api = xml.open(path)
   if not _api then error(path .. " not found") end
- 
+
   LoadInterfaces(_api, result)
   LoadEnums(_api, result)
   LoadStructs(_api, result)
@@ -142,5 +147,5 @@ end
   LoadFunction(_api, result)
   return result
  end
- 
+
  return module

--- a/modules/hmi_connection.lua
+++ b/modules/hmi_connection.lua
@@ -1,39 +1,18 @@
 local json = require("json")
+local api_loader = require("modules/api_loader")
+
 local module = { mt = { __index = { } } }
 
 function module.mt.__index:Connect()
   self.connection:Connect()
 end
 
-local resultCodes =
-{
-  SUCCESS = 0,
-  UNSUPPORTED_REQUEST = 1,
-  UNSUPPORTED_RESOURCE = 2,
-  DISALLOWED = 3,
-  REJECTED = 4,
-  ABORTED = 5,
-  IGNORED = 6,
-  RETRY = 7,
-  IN_USE = 8,
-  DATA_NOT_AVAILABLE = 9,
-  TIMED_OUT = 10,
-  INVALID_DATA = 11,
-  CHAR_LIMIT_EXCEEDED = 12,
-  INVALID_ID = 13,
-  DUPLICATE_NAME = 14,
-  APPLICATION_NOT_REGISTERED = 15,
-  WRONG_LANGUAGE = 16,
-  OUT_OF_MEMORY = 17,
-  TOO_MANY_PENDING_REQUESTS = 18,
-  NO_APPS_REGISTERED = 19,
-  NO_DEVICES_CONNECTED = 20,
-  WARNINGS = 21,
-  GENERIC_ERROR = 22,
-  USER_DISALLOWED = 23,
-  TRUNCATED_DATA = 24,
-  SAVED = 25
-}
+local function getResultCodes( )
+  local hmi_schema = api_loader.init("data/HMI_API.xml")
+  return hmi_schema.interface["Common"].enum["Result"]
+end
+
+local resultCodes = getResultCodes()
 
 function module.mt.__index:Send(text)
   xmlReporter.AddMessage("hmi_connection","Send",{["json"] = tostring(text)})


### PR DESCRIPTION
HMI connection will use values according current HMI_API.
Fixed emum loading - save value parameter in enum