### PR TITLE
Fix collecting SDL logs

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -23,11 +23,11 @@ function CopyInterface()
     local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
     local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
     CopyFile(mobile_api, 'data/MOBILE_API.xml')
-    CopyFile(hmi_api, 'data/HMI_API.xml') 
+    CopyFile(hmi_api, 'data/HMI_API.xml')
   end
 end
 
-function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)    
+function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
   sdl_logger.init_log(get_script_file_name())
   if ExitOnCrash then
     self.exitOnCrash = ExitOnCrash
@@ -55,7 +55,7 @@ function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
     end
   end
   local msg = "SDL had already started from ATF"
-  xmlReporter.AddMessage("StartSDL", {["message"] = msg})  
+  xmlReporter.AddMessage("StartSDL", {["message"] = msg})
   print(console.setattr(msg, "cyan", 1))
   return nil, msg
 end
@@ -64,7 +64,7 @@ function SDL:StopSDL()
   self.autoStarted = false
   local status = self:CheckStatusSDL()
   if status == self.RUNNING then
-    local result = os.execute ('./tools/StopSDL.sh')    
+    local result = os.execute ('./tools/StopSDL.sh')
     if result then
       sdl_logger.close()
       return true

--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -28,7 +28,6 @@ function CopyInterface()
 end
 
 function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
-  sdl_logger.init_log(get_script_file_name())
   if ExitOnCrash then
     self.exitOnCrash = ExitOnCrash
   end
@@ -43,6 +42,9 @@ function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
   if status == self.STOPPED  or status == self.CRASH then
     CopyInterface()
     local result = os.execute ('./tools/StartSDL.sh ' .. pathToSDL .. ' ' .. smartDeviceLinkCore)
+    if config.storeFullSDLLogs == true then
+      sdl_logger.init_log(get_script_file_name())
+    end
     if result then
       local msg = "SDL started"
       xmlReporter.AddMessage("StartSDL", {["message"] = msg})
@@ -66,7 +68,9 @@ function SDL:StopSDL()
   if status == self.RUNNING then
     local result = os.execute ('./tools/StopSDL.sh')
     if result then
-      sdl_logger.close()
+      if config.storeFullSDLLogs == true then
+        sdl_logger.close()
+      end
       return true
     end
   else

--- a/src/network.cc
+++ b/src/network.cc
@@ -6,7 +6,11 @@
 #include <QTcpServer>
 #include <QWebSocket>
 #include <QEventLoop>
+#include <QString>
 #include <unistd.h>
+#include <errno.h>
+#include <cstring>
+#include <cstdio>
 #line 22 "network.nw"
 // TcpClient functions/*{{{*/
 int network_tcp_client(lua_State *L) {/*{{{*/
@@ -29,6 +33,17 @@ QTcpSocket *tcpSocket =
 
   tcpSocket->connectToHost(ip, port);
 
+  QTime timer;
+  timer.start();
+  while (!tcpSocket->waitForConnected()) {
+    tcpSocket->connectToHost(ip, port);
+    // Check elapsed time
+    const int time_waiting_ms = 1000;
+    if (timer.elapsed() > time_waiting_ms){
+      fprintf(stderr, "%s\n%s\n", "Error: Connection not established", strerror(errno));
+      return 1;
+    }
+  }
   return 0;
 }/*}}}*/
 int tcp_socket_read(lua_State *L) {/*{{{*/

--- a/src/network.cc
+++ b/src/network.cc
@@ -7,7 +7,6 @@
 #include <QWebSocket>
 #include <QEventLoop>
 #include <unistd.h>
-
 #line 22 "network.nw"
 // TcpClient functions/*{{{*/
 int network_tcp_client(lua_State *L) {/*{{{*/
@@ -19,18 +18,21 @@ int network_tcp_client(lua_State *L) {/*{{{*/
   return 1;
 }/*}}}*/
 int tcp_socket_connect(lua_State *L) {/*{{{*/
-  
+
 #line 65 "network.nw"
 QTcpSocket *tcpSocket =
   *static_cast<QTcpSocket**>(luaL_checkudata(L, 1, "network.TcpSocket"));
 #line 33 "network.nw"
   const char* ip   = luaL_checkstring(L, 2);
   int         port = luaL_checkinteger(L, 3);
+
+
   tcpSocket->connectToHost(ip, port);
+
   return 0;
 }/*}}}*/
 int tcp_socket_read(lua_State *L) {/*{{{*/
-  
+
 #line 65 "network.nw"
 QTcpSocket *tcpSocket =
   *static_cast<QTcpSocket**>(luaL_checkudata(L, 1, "network.TcpSocket"));
@@ -38,7 +40,7 @@ QTcpSocket *tcpSocket =
   int maxSize = luaL_checkinteger(L, 2);
   if(tcpSocket->isOpen()){
     QByteArray result = tcpSocket->read(maxSize);
-    lua_pushlstring(L, result.data(), result.count()); 
+    lua_pushlstring(L, result.data(), result.count());
   } else {
     fprintf(stderr, "Error: Socket not opened");
   }
@@ -47,18 +49,18 @@ QTcpSocket *tcpSocket =
 
 
 int tcp_socket_read_all(lua_State *L) {/*{{{*/
-  
+
 #line 65 "network.nw"
 QTcpSocket *tcpSocket =
   *static_cast<QTcpSocket**>(luaL_checkudata(L, 1, "network.TcpSocket"));
 #line 40 "network.nw"
   QByteArray result = tcpSocket->readAll();
-  lua_pushlstring(L, result.data(), result.count()); 
+  lua_pushlstring(L, result.data(), result.count());
   return 1;
 }/*}}}*/
 
 int tcp_socket_write(lua_State *L) {/*{{{*/
-  
+
 #line 65 "network.nw"
 QTcpSocket *tcpSocket =
   *static_cast<QTcpSocket**>(luaL_checkudata(L, 1, "network.TcpSocket"));
@@ -67,14 +69,14 @@ QTcpSocket *tcpSocket =
   const char* data = luaL_checklstring(L, 2, &size);
   if(tcpSocket->isOpen()) {
     int result = tcpSocket->write(data, size);
-    lua_pushinteger(L, result); 
+    lua_pushinteger(L, result);
   } else {
     fprintf(stderr, "Error: Socket not opened");
   }
   return 1;
 }/*}}}*/
 int tcp_socket_close(lua_State *L) {/*{{{*/
-  
+
 #line 65 "network.nw"
 QTcpSocket *tcpSocket =
   *static_cast<QTcpSocket**>(luaL_checkudata(L, 1, "network.TcpSocket"));
@@ -83,7 +85,7 @@ QTcpSocket *tcpSocket =
   return 0;
 }/*}}}*/
 int tcp_socket_delete(lua_State *L) {/*{{{*/
-  
+
 #line 65 "network.nw"
 QTcpSocket *tcpSocket =
   *static_cast<QTcpSocket**>(luaL_checkudata(L, 1, "network.TcpSocket"));
@@ -104,7 +106,7 @@ int network_tcp_server(lua_State *L) {/*{{{*/
 }/*}}}*/
 int tcp_server_listen(lua_State *L)/*{{{*/
 {
-  
+
 #line 111 "network.nw"
 QTcpServer *tcpServer =
   *static_cast<QTcpServer**>(luaL_checkudata(L, 1, "network.TcpServer"));
@@ -118,7 +120,7 @@ QTcpServer *tcpServer =
 }/*}}}*/
 int tcp_server_get_connection(lua_State *L)/*{{{*/
 {
-  
+
 #line 111 "network.nw"
 QTcpServer *tcpServer =
   *static_cast<QTcpServer**>(luaL_checkudata(L, 1, "network.TcpServer"));
@@ -136,7 +138,7 @@ QTcpServer *tcpServer =
   return 1;
 }/*}}}*/
 int tcp_server_delete(lua_State *L) {/*{{{*/
-  
+
 #line 111 "network.nw"
 QTcpServer *tcpServer =
   *static_cast<QTcpServer**>(luaL_checkudata(L, 1, "network.TcpServer"));
@@ -158,7 +160,7 @@ int network_web_socket(lua_State *L) {/*{{{*/
 }/*}}}*/
 
 int web_socket_open(lua_State *L) {/*{{{*/
-  
+
 #line 153 "network.nw"
 QWebSocket *webSocket =
   *static_cast<QWebSocket**>(luaL_checkudata(L, 1, "network.WebSocket"));
@@ -169,7 +171,7 @@ QWebSocket *webSocket =
   QEventLoop loop;
   #line 170 "network.nw"
 
-  // Create connection when websocket connected 
+  // Create connection when websocket connected
   QObject::connect(webSocket, SIGNAL(connected()), &loop, SLOT(quit()));
   QObject::connect(webSocket, SIGNAL(disconnected()), &loop, SLOT(quit()));
 
@@ -179,11 +181,11 @@ QWebSocket *webSocket =
     loop.exec();
     usleep(100);
   }
-  
+
   return 0;
 }/*}}}*/
 int web_socket_close(lua_State *L) {/*{{{*/
-  
+
 #line 153 "network.nw"
 QWebSocket *webSocket =
   *static_cast<QWebSocket**>(luaL_checkudata(L, 1, "network.WebSocket"));
@@ -192,7 +194,7 @@ QWebSocket *webSocket =
   return 0;
 }/*}}}*/
 int web_socket_write(lua_State *L) {/*{{{*/
-  
+
 #line 153 "network.nw"
 QWebSocket *webSocket =
   *static_cast<QWebSocket**>(luaL_checkudata(L, 1, "network.WebSocket"));
@@ -206,7 +208,7 @@ QWebSocket *webSocket =
 }/*}}}*/
 
 int web_socket_delete(lua_State *L) {/*{{{*/
-  
+
 #line 153 "network.nw"
 QWebSocket *webSocket =
   *static_cast<QWebSocket**>(luaL_checkudata(L, 1, "network.WebSocket"));


### PR DESCRIPTION
Add waiting for connection for tcp socket.
Start logging right after start SDL.
Start logging only if storeFullSDLLogs flag is true

The same is in [#17](https://github.com/CustomSDL/sdl_atf/pull/17)