### PR TITLE
Fix for ATF behaviour if SDL failed to start

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -28,7 +28,7 @@ function CopyInterface()
 end
 
 function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
-  if ExitOnCrash then
+  if ExitOnCrash ~= nil then
     self.exitOnCrash = ExitOnCrash
   end
   local status = self:CheckStatusSDL()

--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -134,7 +134,9 @@ local function CheckStatus()
   local success = true
   local errorMessage = {}
   if SDL:CheckStatusSDL() == CRASH then
-    -- success = false
+    if SDL.exitOnCrash == true then
+      success = false
+    end
     print(console.setattr("SDL has unexpectedly crashed or stop responding!", "cyan", 1))
     critical(SDL.exitOnCrash)
     SDL:DeleteFile()
@@ -158,7 +160,9 @@ local function CheckStatus()
   module.current_case_name = nil
   if module.current_case_mandatory and not success then
     SDL:StopSDL()
-    -- quit(exit_codes.aborted)
+    if SDL.exitOnCrash == true then
+      quit(exit_codes.aborted)
+    end
   end
   control:next()
 end

--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -1,9 +1,9 @@
 ---- Test Cases executor.
---  
+--
 --  Runs all new methods with a first Capital letter as a Tests.
 --  Tests are being executed one by one and interrupt execution is case of
 --  any critical issues (each Test could be marked as Critical)
---  
+--
 --  For component overview description and a list of responsibilities, please, follow [ATF SAD Component View](https://smartdevicelink.com/en/guides/pull_request/93dee199f30303b4b26ec9a852c1f5261ff0735d/atf/components-view/#test-base).
 --  @module TestBase
 --  @copyright [Ford Motor Company](https://smartdevicelink.com/partners/ford/) and [SmartDeviceLink Consortium](https://smartdevicelink.com/consortium/)
@@ -134,7 +134,7 @@ local function CheckStatus()
   local success = true
   local errorMessage = {}
   if SDL:CheckStatusSDL() == CRASH then
-    success = false
+    -- success = false
     print(console.setattr("SDL has unexpectedly crashed or stop responding!", "cyan", 1))
     critical(SDL.exitOnCrash)
     SDL:DeleteFile()
@@ -158,7 +158,7 @@ local function CheckStatus()
   module.current_case_name = nil
   if module.current_case_mandatory and not success then
     SDL:StopSDL()
-    quit(exit_codes.aborted)
+    -- quit(exit_codes.aborted)
   end
   control:next()
 end


### PR DESCRIPTION
Currently it's no possible to verify negative cases when SDL should fail to start if there is an invalid data in PreloadedPT file

In case if SDL failed to start ATF fails test

This fix allows to have test passed even if SDL fails while starting