### PR TITLE
Fix ATF hangs-up script execution when SDL is already running

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -37,24 +37,24 @@ function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
     local msg = "SDL had already started out of ATF"
     xmlReporter.AddMessage("StartSDL", {["message"] = msg})
     print(console.setattr(msg, "cyan", 1))
-    return nil, msg
+    return false, msg
   end
 
   CopyInterface()
   local result = os.execute ('./tools/StartSDL.sh ' .. pathToSDL .. ' ' .. smartDeviceLinkCore)
-  if config.storeFullSDLLogs == true then
-    sdl_logger.init_log(get_script_file_name())
-  end
+
+  local msg
   if result then
-    local msg = "SDL started"
-    xmlReporter.AddMessage("StartSDL", {["message"] = msg})
-    return true
+    msg = "SDL started"
+    if config.storeFullSDLLogs == true then
+      sdl_logger.init_log(get_script_file_name())
+    end
   else
-    local msg = "SDL had already started not from ATF or unexpectedly crashed"
-    xmlReporter.AddMessage("StartSDL", {["message"] = msg})
+    msg = "SDL had already started not from ATF or unexpectedly crashed"
     print(console.setattr(msg, "cyan", 1))
-    return nil, msg
   end
+  xmlReporter.AddMessage("StartSDL", {["message"] = msg})
+  return result, msg
 
 end
 

--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -33,33 +33,29 @@ function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
   end
   local status = self:CheckStatusSDL()
 
-  while status == self.RUNNING do
-    sleep(1)
-    print('Waiting for SDL shutdown')
-    status = self:CheckStatusSDL()
+  if (status == self.RUNNING) then
+    local msg = "SDL had already started out of ATF"
+    xmlReporter.AddMessage("StartSDL", {["message"] = msg})
+    print(console.setattr(msg, "cyan", 1))
+    return nil, msg
   end
 
-  if status == self.STOPPED  or status == self.CRASH then
-    CopyInterface()
-    local result = os.execute ('./tools/StartSDL.sh ' .. pathToSDL .. ' ' .. smartDeviceLinkCore)
-    if config.storeFullSDLLogs == true then
-      sdl_logger.init_log(get_script_file_name())
-    end
-    if result then
-      local msg = "SDL started"
-      xmlReporter.AddMessage("StartSDL", {["message"] = msg})
-      return true
-    else
-      local msg = "SDL had already started not from ATF or unexpectedly crashed"
-      xmlReporter.AddMessage("StartSDL", {["message"] = msg})
-      print(console.setattr(msg, "cyan", 1))
-      return nil, msg
-    end
+  CopyInterface()
+  local result = os.execute ('./tools/StartSDL.sh ' .. pathToSDL .. ' ' .. smartDeviceLinkCore)
+  if config.storeFullSDLLogs == true then
+    sdl_logger.init_log(get_script_file_name())
   end
-  local msg = "SDL had already started from ATF"
-  xmlReporter.AddMessage("StartSDL", {["message"] = msg})
-  print(console.setattr(msg, "cyan", 1))
-  return nil, msg
+  if result then
+    local msg = "SDL started"
+    xmlReporter.AddMessage("StartSDL", {["message"] = msg})
+    return true
+  else
+    local msg = "SDL had already started not from ATF or unexpectedly crashed"
+    xmlReporter.AddMessage("StartSDL", {["message"] = msg})
+    print(console.setattr(msg, "cyan", 1))
+    return nil, msg
+  end
+
 end
 
 function SDL:StopSDL()

--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -329,7 +329,6 @@ function module:runSDL()
   end
   local result, errmsg = SDL:StartSDL(config.pathToSDL, config.SDL, config.ExitOnCrash)
   if not result then
-    SDL:DeleteFile()
     quit(exit_codes.aborted)
   end
   SDL.autoStarted = true


### PR DESCRIPTION
If SDL has been already started then ATF returns error message.
If StartSDL was unsuccessful then ATF stops work with result code aborted.

According requirements:
In case User attempt to start already successfully running SDL from test case ATF must:
1. return error code with description of failure
2. show this error code with description of failure in console
3. provide this error code with description of failure into Testing report in appropriate section
4. allow defining next step by User (e.g. fail test case execution, continue of test case execution, etc.)