### PR TITLE
Fix ATF behavior during answerHeartbeatFromSDL = true

### DIFF
--- a/modules/services/heartbeat_monitor.lua
+++ b/modules/services/heartbeat_monitor.lua
@@ -11,7 +11,7 @@ function mt.__index:PreconditionForStartHeartbeat()
       return data.frameType == constants.FRAME_TYPE.CONTROL_FRAME and
       data.serviceType == constants.SERVICE_TYPE.CONTROL and
       data.frameInfo == constants.FRAME_INFO.HEARTBEAT   and
-      self.session.sessionId == data.sessionId
+      self.session.sessionId.get() == data.sessionId
     end
     self.expectations:ExpectEvent(event, "Heartbeat")
     :Pin()


### PR DESCRIPTION
self.session.sessionId it is a table, so the expression self.session.sessionId == data.sessionId has always been false and ATF does not respond to HB from SDL
[ATF does not respond to HB from SDL](https://adc.luxoft.com/jira/browse/SDLOPEN-1153)