### PR TITLE
Add ability to check HB expectations outside ATF

### DIFF
--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -62,7 +62,7 @@ end
 --! @return return expectation for StartService Ack
 function mt.__index:StartService(service)
   if service == 7 then
-    return self.mobile_session_impl:StartRPC()
+    return self:StartRPC()
   end
   -- in case StartService(7) it should be change on StartRPC
   return self.mobile_session_impl:StartService(service)
@@ -86,14 +86,24 @@ function mt.__index:StartHeartbeat()
   self.mobile_session_impl:StartHeartbeat()
 end
 
+function mt.__index:SendHeartbeatAck()
+  self.mobile_session_impl:SendHeartbeatAck()
+end
+
 function mt.__index:SetHeartbeatTimeout(timeout)
   self.mobile_session_impl:SetHeartbeatTimeout(timeout)
 end
 
 --! @brief Start service 7 and heartBeat
 --! @return return expectation for expectation for StartService Ack
-function mt.__index:StartRPC()
-  return self.mobile_session_impl:StartRPC()
+function mt.__index:StartRPC(custom_hb_processor)
+  local hb_processor = custom_hb_processor
+  if hb_processor == nil then
+   hb_processor = function (_,_)
+      self.mobile_session_impl:AddHeartbeatExpectation()
+   end
+  end
+  return self.mobile_session_impl:StartRPC():Do(hb_processor)
 end
 
 --! @brief Stop service 7

--- a/modules/mobile_session.lua
+++ b/modules/mobile_session.lua
@@ -86,10 +86,6 @@ function mt.__index:StartHeartbeat()
   self.mobile_session_impl:StartHeartbeat()
 end
 
-function mt.__index:SendHeartbeatAck()
-  self.mobile_session_impl:SendHeartbeatAck()
-end
-
 function mt.__index:SetHeartbeatTimeout(timeout)
   self.mobile_session_impl:SetHeartbeatTimeout(timeout)
 end
@@ -97,13 +93,11 @@ end
 --! @brief Start service 7 and heartBeat
 --! @return return expectation for expectation for StartService Ack
 function mt.__index:StartRPC(custom_hb_processor)
-  local hb_processor = custom_hb_processor
-  if hb_processor == nil then
-   hb_processor = function (_,_)
-      self.mobile_session_impl:AddHeartbeatExpectation()
-   end
-  end
-  return self.mobile_session_impl:StartRPC():Do(hb_processor)
+  custom_hb_processor = custom_hb_processor
+    or function (_,_)
+        self.mobile_session_impl:AddHeartbeatExpectation()
+    end
+  return self.mobile_session_impl:StartRPC():Do(custom_hb_processor)
 end
 
 --! @brief Stop service 7

--- a/modules/mobile_session_impl.lua
+++ b/modules/mobile_session_impl.lua
@@ -54,11 +54,6 @@ function mt.__index:StartHeartbeat()
   self.heartbeat_monitor:StartHeartbeat()
 end
 
-function mt.__index:SendHeartbeatAck()
-  self.heartbeat_monitor:SendHeartbeatAck()
-end
-
-
 function mt.__index:SetHeartbeatTimeout(timeout)
   self.heartbeat_monitor:SetHeartbeatTimeout(timeout)
 end

--- a/modules/mobile_session_impl.lua
+++ b/modules/mobile_session_impl.lua
@@ -54,8 +54,17 @@ function mt.__index:StartHeartbeat()
   self.heartbeat_monitor:StartHeartbeat()
 end
 
+function mt.__index:SendHeartbeatAck()
+  self.heartbeat_monitor:SendHeartbeatAck()
+end
+
+
 function mt.__index:SetHeartbeatTimeout(timeout)
   self.heartbeat_monitor:SetHeartbeatTimeout(timeout)
+end
+
+function mt.__index:AddHeartbeatExpectation()
+  self.heartbeat_monitor:AddHeartbeatExpectation()
 end
 
 function mt.__index:StartRPC()
@@ -63,7 +72,6 @@ function mt.__index:StartRPC()
   ret:Do(function()
       -- Heartbeat
       if self.version > 2 then
-        self.heartbeat_monitor:PreconditionForStartHeartbeat()
         self.heartbeat_monitor:StartHeartbeat()
       end
     end)


### PR DESCRIPTION
Add new function SendHeartbeatAck for sending HBAck from test.
Add parameter to StartRPC - custom heartbeat expectation.
If it omits, the default one will be used.