### PR TITLE
Remove expectation of sending GetVehicleData in HMI OnReady

### DIFF
--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -457,7 +457,6 @@ function module:initHMI_onReady()
         trim = "SE"
       }
     })
-  ExpectRequest("VehicleInfo.GetVehicleData", true, { vin = "52-452-52-752" })
 
   local function button_capability(name, shortPressAvailable, longPressAvailable, upDownAvailable)
     return


### PR DESCRIPTION
According requirement SDL should not send GetVehicleData until mobile app requested it.