### PR TITLE
Revert "Remove expectation of sending GetVehicleData in HMI OnReady"

### DIFF
--- a/modules/connecttest.lua
+++ b/modules/connecttest.lua
@@ -457,6 +457,7 @@ function module:initHMI_onReady()
         trim = "SE"
       }
     })
+  ExpectRequest("VehicleInfo.GetVehicleData", true, { vin = "52-452-52-752" })
 
   local function button_capability(name, shortPressAvailable, longPressAvailable, upDownAvailable)
     return


### PR DESCRIPTION
According to req-t "[GetVehicleData] "vin" storage into PolicyTable" changes need to be reverted
(smartdevicelink/sdl_atf#89)