### PR TITLE
Fix issue with copying of APIs

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -14,19 +14,6 @@ function sleep(n)
   os.execute("sleep " .. tonumber(n))
 end
 
-function CopyFile(file, newfile)
-  return os.execute (string.format('cp "%s" "%s"', file, newfile))
-end
-
-function CopyInterface()
-  if config.pathToSDLInterfaces~="" and config.pathToSDLInterfaces~=nil then
-    local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
-    local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
-    CopyFile(mobile_api, 'data/MOBILE_API.xml')
-    CopyFile(hmi_api, 'data/HMI_API.xml')
-  end
-end
-
 function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
   if ExitOnCrash ~= nil then
     self.exitOnCrash = ExitOnCrash
@@ -40,7 +27,6 @@ function SDL:StartSDL(pathToSDL, smartDeviceLinkCore, ExitOnCrash)
     return false, msg
   end
 
-  CopyInterface()
   local result = os.execute ('./tools/StartSDL.sh ' .. pathToSDL .. ' ' .. smartDeviceLinkCore)
 
   local msg

--- a/modules/function_id.lua
+++ b/modules/function_id.lua
@@ -1,4 +1,20 @@
 local xml = require('xml')
+
+local function CopyFile(file, newfile)
+  return os.execute (string.format('cp "%s" "%s"', file, newfile))
+end
+
+local function CopyInterface()
+  if config.pathToSDLInterfaces~="" and config.pathToSDLInterfaces~=nil then
+    local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
+    local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
+    CopyFile(mobile_api, 'data/MOBILE_API.xml')
+    CopyFile(hmi_api, 'data/HMI_API.xml')
+  end
+end
+
+CopyInterface()
+
 local module = { }
 
 module.mobile_functions = { }


### PR DESCRIPTION
This fix is related to copying of APIs
If "config.pathToSDLInterfaces" parameter is defined in config.lua APIs are copied from defined path to ./data directory
But reading of functionIds from these APIs was performed before the copying
These led to fail the test for the 1st try and passed for the 2nd and next tries

So the fix is to move copying of APIs into "function_id" module
And tests are able to work correctly for the 1st try now