### PR TITLE
Fix issue regarding StopSDL and SDL logger

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -136,19 +136,16 @@ function SDL:StopSDL()
   self.autoStarted = false
   local status = self:CheckStatusSDL()
   if status == self.RUNNING then
-    local result = os.execute ('./tools/StopSDL.sh')
-    if result then
-      if config.storeFullSDLLogs == true then
-        sdl_logger.close()
-      end
-      return true
-    end
+    os.execute('./tools/StopSDL.sh')
   else
     local msg = "SDL had already stopped"
     xmlReporter.AddMessage("StopSDL", {["message"] = msg})
     print(console.setattr(msg, "cyan", 1))
-    return nil, msg
   end
+  if config.storeFullSDLLogs == true then
+    sdl_logger.close()
+  end
+  return true
 end
 
 --- SDL status check

--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -145,7 +145,6 @@ function SDL:StopSDL()
   if config.storeFullSDLLogs == true then
     sdl_logger.close()
   end
-  return true
 end
 
 --- SDL status check


### PR DESCRIPTION
Fix is related to the case when SDL logger was not closed.
This led to long execution of StopSDL() function until default timeout for the socket (TIME_WAIT) expires.