### PR TITLE
Remove forced socket closing procedure

### DIFF
--- a/modules/sdl_logger.lua
+++ b/modules/sdl_logger.lua
@@ -114,7 +114,6 @@ end
 --- Close SDL logger connection to SDL
 function SdlLogger.close()
   if(SdlLogger.socket) then SdlLogger.socket:close() end
-  os.execute('bash ./tools/WaitClosingSocket.sh '..config.sdl_logs_port)
 end
 
 return SdlLogger

--- a/tools/WaitClosingSocket.sh
+++ b/tools/WaitClosingSocket.sh
@@ -1,7 +1,0 @@
-socket=$1
-function is_telnet_socket_closed {
-    #TODO(AKutsan) APPLINK-15273 Remove waiting for closing telnet port
-    res=$(netstat -pna 2>/dev/null | grep $socket | wc -l);
-    [ $res -gt 1 ] && return 1 || return 0;
-}
-while ! is_telnet_socket_closed ; do sleep 1; done


### PR DESCRIPTION
Forced closing of socket procedure for SDL logger is not required anymore