### PR TITLE
Handling of multiple validations

### DIFF
--- a/modules/config.lua
+++ b/modules/config.lua
@@ -19,6 +19,8 @@ config.mobileHost = "localhost"
 config.mobilePort = 12345
 --- Define timeout for Heartbeat in msec
 config.heartbeatTimeout = 7000
+--- Flag which defines whether ATF show all failed validations for particular expectation or just a first one
+config.allFailedValidations = false
 --- Define default version of Ford protocol
 --
 -- 1 - basic

--- a/modules/config.lua
+++ b/modules/config.lua
@@ -19,8 +19,8 @@ config.mobileHost = "localhost"
 config.mobilePort = 12345
 --- Define timeout for Heartbeat in msec
 config.heartbeatTimeout = 7000
---- Flag which defines whether ATF show all failed validations for particular expectation or just a first one
-config.allFailedValidations = false
+--- Flag which defines whether ATF check all validations for particular expectation or just till the first which fails
+config.checkAllValidations = false
 --- Define default version of Ford protocol
 --
 -- 1 - basic

--- a/modules/config.lua
+++ b/modules/config.lua
@@ -19,7 +19,7 @@ config.mobileHost = "localhost"
 config.mobilePort = 12345
 --- Define timeout for Heartbeat in msec
 config.heartbeatTimeout = 7000
---- Flag which defines whether ATF check all validations for particular expectation or just till the first which fails
+--- Flag which defines whether ATF checks all validations for particular expectation or just till the first which fails
 config.checkAllValidations = false
 --- Define default version of Ford protocol
 --

--- a/modules/event_dispatcher.lua
+++ b/modules/event_dispatcher.lua
@@ -8,6 +8,7 @@
 
 expectations = require('expectations')
 events = require('events')
+local config = require('config')
 
 --- Type which is responsible for dispatching events with expectations
 -- @type EventDispatcher
@@ -146,8 +147,8 @@ function mt.__index:RaiseEvent(connection, data)
       if exp.verifyData then
         for k, v in pairs(exp.verifyData) do
             v(exp, data)
-            if (exp.status == expectations.FAILED) then
-                break
+            if (config.allFailedValidations == false) and (exp.isAtLeastOneFail == true) then
+              break
             end
         end
       end

--- a/modules/event_dispatcher.lua
+++ b/modules/event_dispatcher.lua
@@ -147,7 +147,7 @@ function mt.__index:RaiseEvent(connection, data)
       if exp.verifyData then
         for k, v in pairs(exp.verifyData) do
             v(exp, data)
-            if (config.allFailedValidations == false) and (exp.isAtLeastOneFail == true) then
+            if (config.checkAllValidations == false) and (exp.isAtLeastOneFail == true) then
               break
             end
         end

--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -138,10 +138,15 @@ function Expectations.Expectation(name, connection)
         if not self.errorMessage["ValidIf"] then
           self.errorMessage["ValidIf"] = ""
         end
-        self.errorMessage["ValidIf"] = self.errorMessage["ValidIf"] .. "\n" .. msg
+        if msg ~= nil and msg ~= "" then
+          self.errorMessage["ValidIf"] = self.errorMessage["ValidIf"] .. "\n" .. tostring(msg)
+        end
       else
         if msg ~= nil and msg ~= "" then
-          self.errorMessage["WARNING"] = msg
+          if not self.warningMessage["WARNING"] then
+            self.warningMessage["WARNING"] = ""
+          end
+          self.warningMessage["WARNING"] = self.warningMessage["WARNING"] .. "\n" .. tostring(msg)
         end
       end
     end
@@ -161,6 +166,7 @@ function Expectations.Expectation(name, connection)
     connection = connection, -- Network connection
     occurences = 0, -- Expectation complience times
     errorMessage = { }, -- If failed, error message to display
+    warningMessage = { }, -- Warning message to display
     actions = { }, -- Sequence of actions to be executed when complied
     pinned = false, -- True if the expectation is pinned
     list = nil, -- ExpectationsList the expectation belongs to

--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -97,7 +97,7 @@ function Expectations.Expectation(name, connection)
   --- Perform base validation of expectation and set result into `Test`
   function mt.__index:validate()
     if self.isAtLeastOneFail == true then
-      if config.allFailedValidations == false or self.occurences == self.timesGE then
+      if config.checkAllValidations == false or self.timesGE == nil or self.occurences == self.timesGE then
         self.status = Expectations.FAILED
       end
     end

--- a/modules/format.lua
+++ b/modules/format.lua
@@ -10,7 +10,7 @@
 --- Singleton table which is used for perform formated output into console
 -- @table Format
 local Format = { }
-console = require('console')
+local console = require('console')
 local config = require('config')
 
 --- Print formated information about test step result into console
@@ -20,7 +20,7 @@ local config = require('config')
 -- @tparam string errorMessage Error message
 -- @tparam number timespan Duration of test step execution in msec
 -- @treturn Format Module Format
-function Format.PrintCaseResult(startCaseTime, caseName, success, errorMessage, timespan)
+function Format.PrintCaseResult(startCaseTime, caseName, success, errorMessage, warningMessage, timespan)
   caseName = tostring(caseName)
   if #caseName > 85 then
     caseName = string.sub(caseName, 1, 82) .. "..."
@@ -55,11 +55,11 @@ function Format.PrintCaseResult(startCaseTime, caseName, success, errorMessage, 
     end
   end
   -- Print warnings
-  if success and errorMessage then
-    for k, v in pairs(errorMessage) do
+  if warningMessage then
+    for k, v in pairs(warningMessage) do
       local errmsg = " " .. k .. ": " .. v
       if config.color then
-        print(console.setattr(errmsg, "yellow", 1))
+        print(console.setattr(errmsg, "brown", 1))
       else
         print(errmsg)
       end

--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -160,6 +160,7 @@ local function CheckStatus()
   -- Check the test status
   local success = true
   local errorMessage = {}
+  local warningMessage = {}
   if SDL:CheckStatusSDL() == CRASH then
     if SDL.exitOnCrash == true then
       success = false
@@ -179,8 +180,11 @@ local function CheckStatus()
     for k, v in pairs(e.errorMessage) do
       errorMessage[e.name .. ": " .. k] = v
     end
+    for k, v in pairs(e.warningMessage) do
+      warningMessage[e.name .. ": " .. k] = v
+    end
   end
-  fmt.PrintCaseResult(Test.current_case_time, Test.current_case_name, success, errorMessage, timestamp() - Test.ts)
+  fmt.PrintCaseResult(Test.current_case_time, Test.current_case_name, success, errorMessage, warningMessage, timestamp() - Test.ts)
   xmlReporter.CaseMessageTotal(Test.current_case_name,{ ["result"] = success, ["timestamp"] = (timestamp() - Test.ts)} )
   if (not success) then xmlReporter.AddMessage("ErrorMessage", {["Status"] = "FAILD"}, errorMessage ) end
   Test.expectations_list:Clear()


### PR DESCRIPTION
This PR is related to the case when a particular expectation has a few validations.
Eg.: 
``` 
ExpectNotification("SDL.OnStatusUpdate") 
:ValidIf(function() ... end)
:ValidIf(function() ... end)
```

Currently if both validations fail ATF will show only one error in log
In this PR added possibility to report errors for all failed validations

ATF behavior is configured by ```allFailedValidations``` parameter of config file. By default it is ```false```
  