### PR TITLE
Change priority of expectations processing

### DIFF
--- a/modules/events.lua
+++ b/modules/events.lua
@@ -30,7 +30,7 @@ setmetatable(Events.timeoutEvent, event_mt)
 function Events.Event()
   local ret = {
     --- Level of event
-    level = 3
+    level = 2
   }
   setmetatable(ret, event_mt)
   return ret

--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -134,6 +134,7 @@ function control.runNextCase()
     local function wait(pConnection)
       local timeout = config.zeroOccurrenceTimeout
       local event = events.Event()
+      event.level = 3
       event.matches = function(event1, event2) return event1 == event2 end
 
       local ret = Expectation("Wait", pConnection)


### PR DESCRIPTION
This PR changes priority of expectations processing: system ones have to be processed firstly
This change already introduced in https://github.com/smartdevicelink/sdl_atf/pull/107