### PR TITLE
Add possibility to define path to SDL APIs in command line parameter

### DIFF
--- a/modules/atf/util.lua
+++ b/modules/atf/util.lua
@@ -282,6 +282,12 @@ function AtfUtil.sdl_core(str)
   config.pathToSDL = str
 end
 
+--- Overwrite property pathToSDLInterfaces in configuration of ATF
+-- @tparam string str Value
+function AtfUtil.sdl_interfaces(str)
+  config.pathToSDLInterfaces = str
+end
+
 function parse_cmdl()
   arguments = utils.getopt(argv, opts)
   if (arguments) then
@@ -318,10 +324,24 @@ function declare_short_opt(...)
   utils.declare_short_opt(...)
 end
 
+local function copy_file(file, newfile)
+  return os.execute(string.format('cp "%s" "%s"', file, newfile))
+end
+
+local function copy_interfaces()
+  if config.pathToSDLInterfaces ~= "" and config.pathToSDLInterfaces ~= nil then
+    local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
+    local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
+    copy_file(mobile_api, 'data/MOBILE_API.xml')
+    copy_file(hmi_api, 'data/HMI_API.xml')
+  end
+end
+
 --- Test script execution
 -- @param script_name path to the script file with a tests
 function script_execute(script_name)
   check_required_fields()
+  copy_interfaces()
   AtfUtil.script_file_name = script_name
   xmlReporter = xmlReporter.init(tostring(script_name))
   atf_logger = atf_logger.init_log(tostring(script_name))

--- a/modules/function_id.lua
+++ b/modules/function_id.lua
@@ -9,21 +9,6 @@
 
 local xml = require('xml')
 
-local function CopyFile(file, newfile)
-  return os.execute (string.format('cp "%s" "%s"', file, newfile))
-end
-
-local function CopyInterface()
-  if config.pathToSDLInterfaces~="" and config.pathToSDLInterfaces~=nil then
-    local mobile_api = config.pathToSDLInterfaces .. '/MOBILE_API.xml'
-    local hmi_api = config.pathToSDLInterfaces .. '/HMI_API.xml'
-    CopyFile(mobile_api, 'data/MOBILE_API.xml')
-    CopyFile(hmi_api, 'data/HMI_API.xml')
-  end
-end
-
-CopyInterface()
-
 local FunctionId = { }
 
 --- Table with mobile functions.

--- a/modules/launch.lua
+++ b/modules/launch.lua
@@ -24,6 +24,7 @@ declare_long_opt("--storeFullSDLLogs", NoArgument, "Store Full SDL Logs enable")
 declare_long_opt("--heartbeat", RequiredArgument, "Hearbeat timeout value")
 declare_long_opt("--sdl-core", RequiredArgument, "Path to folder with SDL binary")
 declare_long_opt("--report-mark", RequiredArgument, "Marker of testing report")
+declare_long_opt("--sdl-interfaces", RequiredArgument, "Path to folder with APIs")
 
 local script_files = parse_cmdl()
 


### PR DESCRIPTION
ATF depends on SDL interfaces (APIs). They are required in order to send correct data for RPCs.
APIs can vary from one SDL feature to another. 
ATF has possibility to copy appropriate APIs from defined path (by ```config.pathToSDLInterfaces``` parameter).
But redefining this parameter each time is not convenient.
 
This PR add additional possibility for ATF to set path to APIs by defining the value for new command line parameter ```--sdl-interfaces```

In case if it's defined the value of ```config.pathToSDLInterfaces```  parameter will be overwritten. 