### PR TITLE
Add delay in SDL stop function

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -145,6 +145,7 @@ function SDL:StopSDL()
   if config.storeFullSDLLogs == true then
     sdl_logger.close()
   end
+  sleep(1)
 end
 
 --- SDL status check


### PR DESCRIPTION
Currently if SDL stops and then started again - log for the 2nd start is empty.
Delay is required for ```SDLStop()``` function in order SDL has enough time to close connection for logger.
