### PR TITLE
Fix calculation of multi-frame message size

### DIFF
--- a/modules/protocol_handler/protocol_handler.lua
+++ b/modules/protocol_handler/protocol_handler.lua
@@ -270,6 +270,7 @@ function mt.__index:Parse(binary, validateJson, frameHandler)
         table.insert(res, msg)
       elseif msg.frameType == constants.FRAME_TYPE.FIRST_FRAME then
         self.frames[msg.messageId] = ""
+        self.totalSize = msg.size
       elseif msg.frameType == constants.FRAME_TYPE.SINGLE_FRAME then
         if isBinaryDataHasHeader(msg) then
           parseBinaryHeader(msg, validateJson)
@@ -277,9 +278,12 @@ function mt.__index:Parse(binary, validateJson, frameHandler)
         table.insert(res, msg)
       elseif msg.frameType == constants.FRAME_TYPE.CONSECUTIVE_FRAME then
         self.frames[msg.messageId] = self.frames[msg.messageId] .. msg.binaryData
+        self.totalSize = self.totalSize + msg.size
         if msg.frameInfo == constants.FRAME_INFO.LAST_FRAME then
           msg.binaryData = self.frames[msg.messageId]
+          msg.size = self.totalSize
           self.frames[msg.messageId] = nil
+          self.totalSize = nil
           if isBinaryDataHasHeader(msg) then
             parseBinaryHeader(msg, validateJson)
           end


### PR DESCRIPTION
Test [001_PTU_all_flows.lua](https://github.com/smartdevicelink/sdl_atf_test_scripts/blob/develop/test_scripts/Smoke/Policies/001_PTU_all_flows.lua) reveals an issue that size of multi-frame messages is calculated incorrectly. 
Last frame size was used for the total size of such multi-frame message.
This PR fixes calculation logic