### PR TITLE
Fix handling of events when SDL stopped

### DIFF
--- a/modules/testbase.lua
+++ b/modules/testbase.lua
@@ -202,7 +202,8 @@ local function CheckStatus()
     print(console.setattr("SDL has unexpectedly crashed or stop responding!", "cyan", 1))
     critical(SDL.exitOnCrash)
     SDL:DeleteFile()
-  elseif Test.expectations_list:Any(function(e) return not e.status end) then return end
+  end
+  if Test.expectations_list:Any(function(e) return not e.status end) then return end
   for _, e in ipairs(Test.expectations_list) do
     if e.status ~= SUCCESS then
       success = false


### PR DESCRIPTION
Currently ATF stops processing of expectations if SDL is stopped.
However there are internal expectations such as waiters, custom expectations etc. that needs to be processed even if SDL is stopped.
This PR allows ATF to proceed with all registered expectations regardless of SDL status.