### PR TITLE
WIP add full app id to config

### DIFF
--- a/modules/config.lua
+++ b/modules/config.lua
@@ -94,7 +94,8 @@ config.application1 =
     languageDesired = 'EN-US',
     hmiDisplayLanguageDesired = 'EN-US',
     appHMIType = { "NAVIGATION" },
-    appID = "0000001",
+    appID = "0001",
+    fullAppID = "0000001",
     deviceInfo =
     {
       os = "Android",
@@ -121,7 +122,8 @@ config.application2 =
     languageDesired = 'EN-US',
     hmiDisplayLanguageDesired = 'EN-US',
     appHMIType = { "NAVIGATION" },
-    appID = "0000002",
+    appID = "0002",
+    fullAppID = "0000002",
     deviceInfo =
     {
       os = "Android",
@@ -148,7 +150,8 @@ config.application3 =
     languageDesired = 'EN-US',
     hmiDisplayLanguageDesired = 'EN-US',
     appHMIType = { "NAVIGATION" },
-    appID = "0000003",
+    appID = "0003",
+    fullAppID = "0000003",
     deviceInfo =
     {
       os = "Android",
@@ -175,7 +178,8 @@ config.application4 =
     languageDesired = 'EN-US',
     hmiDisplayLanguageDesired = 'EN-US',
     appHMIType = { "NAVIGATION" },
-    appID = "0000004",
+    appID = "0004",
+    fullAppID = "0000004",
     deviceInfo =
     {
       os = "Android",
@@ -202,7 +206,8 @@ config.application5 =
     languageDesired = 'EN-US',
     hmiDisplayLanguageDesired = 'EN-US',
     appHMIType = { "NAVIGATION" },
-    appID = "0000005",
+    appID = "0005",
+    fullAppID = "0000005",
     deviceInfo =
     {
       os = "Android",


### PR DESCRIPTION
Fixes #142 
> ATF needs some changes for https://github.com/smartdevicelink/sdl_core/issues/2159. The evolution proposal adds a new mandatory fullAppID parameter to `RegisterAppInterface`, so ATF has to provide such a parameter for every parameter set used for that RPC, including the ones in the config file.

This adds a fullAppID parameter to the `RegisterAppInterface` parameters in the config file and changes the old short-form `appID` to a smaller string so that there are no overlaps/false positives.