### PR TITLE
Update api_loader to parse interface version

### DIFF
--- a/modules/api_loader.lua
+++ b/modules/api_loader.lua
@@ -13,6 +13,7 @@
 local xml = require('xml')
 
 local apiLoader = { }
+local interfaceVersion = { }
 
 --- Include result codes that are elements in functions from Mobile Api.
 -- Each function with paremeter resultCode that has type Result
@@ -126,12 +127,28 @@ local function LoadFunction( api, dest  )
   end
 end
 
+local function GetAPIVersion(version_str)
+  local version_arr = {0,0,0}
+  local index = 0
+  for i in string.gmatch(version_str, "([^.]+)") do
+      version_arr[index] = i
+      index = index + 1
+  end
+  local version = {
+      majorVersion = version_arr[0],
+      minorVersion = version_arr[1],
+      patchVersion = version_arr[2]
+  }
+  return version
+end
+
 --- Load interfaces from api. Each function, enum and struct will be
 -- kept inside appropriate interface
 local function LoadInterfaces( api, dest )
   local interfaces = api:xpath("//interface")
   for _, s in ipairs(interfaces) do
     name = s:attr("name")
+    version_str = s:attr("version")
     dest.interface[name] ={}
     dest.interface[name].body = s
     dest.interface[name].type={}
@@ -143,6 +160,7 @@ local function LoadInterfaces( api, dest )
     dest.interface[name].type['notification'].functions={}
     dest.interface[name].enum={}
     dest.interface[name].struct={}
+    dest.interface[name].version = GetAPIVersion(version_str)
   end
 end
 
@@ -152,7 +170,7 @@ end
 -- @tparam string path Path to the xml file
 -- @tparam string include_parent_name Parent name
 -- @treturn table lua table with all xml RPCs
- function apiLoader.init(path, include_parent_name)
+function apiLoader.init(path, include_parent_name)
   apiLoader.include_parent_name = include_parent_name
   local result = {}
   result.interface = { }
@@ -166,6 +184,6 @@ end
 
   LoadFunction(_api, result)
   return result
- end
+end
 
- return apiLoader
+return apiLoader

--- a/modules/load_schema.lua
+++ b/modules/load_schema.lua
@@ -22,10 +22,13 @@ LoadSchema.response = 'response'
 LoadSchema.request = 'request'
 LoadSchema.notification = 'notification'
 if (not LoadSchema.mob_schema) then
-  LoadSchema.mob_schema = validator.CreateSchemaValidator(api_loader.init("data/MOBILE_API.xml"))
+  LoadSchema.mob_api = api_loader.init("data/MOBILE_API.xml")
+  LoadSchema.mob_api_version = LoadSchema.mob_api.interface["SmartDeviceLink RAPI"].version
+  LoadSchema.mob_schema = validator.CreateSchemaValidator(LoadSchema.mob_api)
 end
 if (not LoadSchema.hmi_schema) then
-  LoadSchema.hmi_schema = validator.CreateSchemaValidator(api_loader.init("data/HMI_API.xml"))
+  LoadSchema.hmi_api = api_loader.init("data/HMI_API.xml")
+  LoadSchema.hmi_schema = validator.CreateSchemaValidator(LoadSchema.hmi_api)
 end
 
 return LoadSchema


### PR DESCRIPTION
Used for [mobile version negotiation pr.
](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2002)

Parses the interface version of the mobile api and converts it into a syncMsgVersion struct.