### PR TITLE
Increase accuracy of internal QT timer

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -4,6 +4,7 @@
 int timer_create(lua_State *L) {
   QTimer **p = static_cast<QTimer**>(lua_newuserdata(L, sizeof(QTimer*)));
   *p = new QTimer();
+  (*p)->setTimerType(Qt::PreciseTimer);
   luaL_getmetatable(L, "timers.Timer");
   lua_setmetatable(L, -2);
   return 1;


### PR DESCRIPTION
Fixes #[152](https://github.com/smartdevicelink/sdl_atf/issues/152)

This PR is **ready** for review.

### Summary
Accuracy of QT timer is increased from default one (accuracy within 5% of the desired interval) to millisecond accuracy 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
