### PR TITLE
Remove Lua MQ submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
     path = modules/json4lua
     url = https://github.com/CustomSDL/json4lua
     branch = master
-[submodule "modules/luamq"]
-	path = modules/luamq
-	url = https://github.com/dboltovskyi/luamq
-	branch = master

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SOURCES= src/lua_interpreter.cc \
 	src/qdatetime.cc \
 	src/timers.cc
 
-all: interp modules/libxml.so modules/libmq.so modules/libluaopenssl.so
+all: interp modules/libxml.so modules/libluaopenssl.so
 
 interp: $(PROJECT).mk $(SOURCES)
 	make -f $<
@@ -22,11 +22,6 @@ interp: $(PROJECT).mk $(SOURCES)
 
 modules/libxml.so: src/lua_xml.cc
 	$(CXX) $(CXXFLAGS) -shared -std=c++11 $< -o modules/libxml.so -g -I/usr/include/libxml2 -llua5.2 -lxml2 -fPIC
-
-modules/libmq.so:
-	cd ./modules/luamq/; make
-	cp -f ./modules/luamq/src/mq.so ./modules/libmq.so
-	rm -f ./modules/luamq/src/mq.so ./modules/luamq/src/lua-mq.o
 
 modules/libluaopenssl.so: src/lua_openssl.cc
 	$(CXX) $(CXXFLAGS) -shared -std=c++11 $< -o modules/libluaopenssl.so -g -I/usr/include/openssl -llua5.2 -lssl -lcrypto -fPIC


### PR DESCRIPTION
Fixes #[156](https://github.com/smartdevicelink/sdl_atf/issues/156)

This PR is **ready** for review.

### Summary
Remove `luamq` submodule.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
