### PR TITLE
Get interface name from API

### DIFF
--- a/modules/load_schema.lua
+++ b/modules/load_schema.lua
@@ -23,7 +23,8 @@ LoadSchema.request = 'request'
 LoadSchema.notification = 'notification'
 if (not LoadSchema.mob_schema) then
   LoadSchema.mob_api = api_loader.init("data/MOBILE_API.xml")
-  LoadSchema.mob_api_version = LoadSchema.mob_api.interface["SmartDeviceLink RAPI"].version
+  local interfaceName = next(LoadSchema.mob_api.interface)
+  LoadSchema.mob_api_version = LoadSchema.mob_api.interface[interfaceName].version
   LoadSchema.mob_schema = validator.CreateSchemaValidator(LoadSchema.mob_api)
 end
 if (not LoadSchema.hmi_schema) then


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Currently ATF can load only API.xml with the interface "SmartDeviceLink RAPI", so in case the interface name will be updated, ATF also must be updated, that is not the good approach.

In this PR the interface name is read from API.XML during the loading.

### Changelog
##### Breaking Changes
* Update load_shema.sh with reading of the interface name from API.XML

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)