### PR TITLE
Move initialization of mobileSecurities to Security Manager constructor

### DIFF
--- a/modules/mobile_session_impl.lua
+++ b/modules/mobile_session_impl.lua
@@ -281,6 +281,7 @@ function mt.__index:StopRPC()
   return ret
     :Do(function(_, _)
       self.security:unregisterAllSecureServices()
+      self.security:unregisterSessionSecurity()
     end)
 end
 

--- a/modules/security/security_manager.lua
+++ b/modules/security/security_manager.lua
@@ -133,6 +133,10 @@ function security_mt.__index:registerSessionSecurity()
   end
 end
 
+function security_mt.__index:unregisterSessionSecurity()
+  SecurityManager.mobileSecurities[self.session.sessionId.get()] = nil
+end
+
 --- Register service into mobile session security. Service assumed as secure
 -- @tparam number service Service number
 function security_mt.__index:registerSecureService(service)


### PR DESCRIPTION
In case if mobile session is re-created `mobileSecurities` in `SecurityManager` still contains link to a previous session.
This fix introduces `unregisterSessionSecurity` method to `SecurityManager` module.
And this method is invoked in `StopRPC` function.