### PR TITLE
Make 1st frame of multi-frame messages always unencrypted

### DIFF
--- a/modules/protocol_handler/protocol_handler.lua
+++ b/modules/protocol_handler/protocol_handler.lua
@@ -359,7 +359,7 @@ function mt.__index:Compose(message)
     -- Create message firstframe
     local firstFrameMessage = {
       version = message.version,
-      encryption = message.encryption,
+      encryption = false, -- 1st frame has to be always unencrypted
       frameType = constants.FRAME_TYPE.FIRST_FRAME,
       serviceType = message.serviceType,
       frameInfo = 0,


### PR DESCRIPTION
**Summary:**
In case of multi-frame messages 1st frame has to be always unencrypted.

**Description:**
1st frame incorporates `Total message size` and `Number of consecutive frames` data.
In case if it's encrypted SDL is unable to know how many consecutive frames it has to proceed.
Since SDL tries to do as much as possible sometimes this lack of knowledge does not lead to message drop.
However in case if number of frames > 64 it will very likely lead to message drop.
This PR makes 1st frame to be always unencrypted. 