### PR TITLE
Switch off XML Report by default

### DIFF
--- a/modules/atf_logger.lua
+++ b/modules/atf_logger.lua
@@ -49,9 +49,9 @@ local controlMessagesHB = {}
 controlMessagesHB[ford_constants.FRAME_INFO.HEARTBEAT] = "Heartbeat"
 controlMessagesHB[ford_constants.FRAME_INFO.HEARTBEAT_ACK] = "HeartbeatACK"
 
-Logger.mobile_log_format = "%s (%s) [%s, sessionId: %s, version: %s, frameType: %s, "
-      .. "encryption: %s, serviceType: %s, frameInfo: %s, messageId: %s, binaryDataSize: %s] : %s \n"
-Logger.hmi_log_format = "%s (%s) : %s \n"
+Logger.mobile_log_format = "%s [%s] [%s, sessionId: %s, version: %s, frameType: %s, "
+      .. "encryption: %s, serviceType: %s, frameInfo: %s, messageId: %s, binaryDataSize: %s] : %s \n\n"
+Logger.hmi_log_format = "%s [%s] %s \n"
 
 local rpc_function_id
 
@@ -93,7 +93,7 @@ function Logger.formated_time(without_date)
   if without_date == true then
     return qdatetime.get_datetime("hh:mm:ss,zzz")
   end
-  return qdatetime.get_datetime("dd MM yyyy hh:mm:ss, zzz")
+  return qdatetime.get_datetime("dd-MM-yyyy hh:mm:ss,zzz")
 end
 
 --- Check message is it HMI tract
@@ -123,7 +123,7 @@ end
 -- @tparam string tract Tract information
 -- @tparam string message String representation of message from mobile application to SDL
 function Logger:MOBtoSDL(tract, message)
-  local log_str = string.format(Logger.mobile_log_format,"MOB->SDL ", Logger.formated_time(),
+  local log_str = string.format(Logger.mobile_log_format,"MOB->SDL", Logger.formated_time(),
     get_function_name(message), message.sessionId, message.version, message.frameType,
     message.encryption, message.serviceType, message.frameInfo, message.messageId, getBinaryDataSize(message.binaryData), message.payload)
   if is_hmi_tract(tract, message) then
@@ -167,7 +167,7 @@ end
 -- @tparam string tract Tract information
 -- @tparam string message String representation of message from HMI to SDL
 function Logger:HMItoSDL(tract, message)
-  local log_str = string.format(Logger.hmi_log_format, "HMI->SDL", Logger.formated_time(), message)
+  local log_str = string.format(Logger.hmi_log_format, "HMI->SDL", Logger.formated_time(), message .. "\n")
   if is_hmi_tract(tract, message) then
     self.atf_log_file:write(log_str)
   end
@@ -244,10 +244,9 @@ function Logger.init_log(script_name)
   return Logger
 end
 
---- Store auxiliary message about start of new test step of test scenario into ATF log file (only if `config.excludeReport` is set to `false`)
+--- Store auxiliary message about start of new test step of test scenario into ATF log file
 -- @tparam string test_case Test step name
 function Logger.LOGTestCaseStart(test_case)
-  if config.excludeReport then return end
   Logger:StartTestCase(test_case)
 end
 
@@ -255,7 +254,6 @@ end
 -- @tparam string tract Tract information
 -- @tparam string message String representation of message
 function Logger.LOG(tract, message)
-  if config.excludeReport then return end
   Logger[tract](Logger, tract, message)
 end
 

--- a/modules/config.lua
+++ b/modules/config.lua
@@ -68,7 +68,7 @@ config.ShowTimeInConsole = true
 --- Flag which defines whether ATF performs validation of Mobile and HMI messages by API
 config.ValidateSchema = true
 --- Flag which defines whether ATF ignores collecting of reports
-config.excludeReport = false
+config.excludeReport = true
 --- Flag which defines whether ATF creates full ATF logs (with json files and service messages)
 config.storeFullATFLogs = true
 --- Flag which defines whether ATF stores full SDLCore logs


### PR DESCRIPTION
Fix: #169

This PR is **ready** for review.

### Summary
Currently ATF creates two reports:
1. ATF report - is a simple text file with all messages which are sent/or received by ATF through both SDL communication channels: MOBILE and HMI 
2. XML Report - is XML file with the messages plus additional information on actual and expected results

Since (2) is in XML format which has some structure the whole document needs to be rebuilt every time new message sent/received.
Moreover content of the document needs to be stored in internal memory while script is executing.

This lead to significant performance degradation on slow environments in case of long scripts.

Since this report is rarely used nowadays the solution is to switch it off by default.

An alternative solution could be usage of another format (not XML) for this report.
However it requires much more time for implementation and motivation is not strong enough.

### Changelog
- XML Report is switched off in default configuration
- dependency on `excludeReport` configuration parameter is removed in ATF Log (1)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)