### PR TITLE
Fix delay for zero expectations in case of callbacks

### DIFF
--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -46,6 +46,9 @@ function Expectations.Expectation(name, connection)
     else
       error("Expectation:Times() must be called with number or Cardinality argument")
     end
+    if self.timesLE == 0 and self.timesGE == 0 then
+      self.isDelayNeedsToBeApplied = true
+    end
     return self
   end
 
@@ -170,7 +173,8 @@ function Expectations.Expectation(name, connection)
     actions = { }, -- Sequence of actions to be executed when complied
     pinned = false, -- True if the expectation is pinned
     list = nil, -- ExpectationsList the expectation belongs to
-    isAtLeastOneFail = false -- True if at least one validation fails
+    isAtLeastOneFail = false, -- True if at least one validation fails
+    isDelayNeedsToBeApplied = false -- True if delay for zero occurrence expectation needs to be applied
   }
 
   setmetatable(e, mt)


### PR DESCRIPTION
Fix: #173

This PR is **ready** for review.

### Summary
Now ATF performs check on zero expectations periodically in `CheckStatus()` function.
In case if new such expectations is found ATF will apply delay.

### Changelog
- Check on presence of zero expectations moved from `runNextCase()` to `CheckStatus()` function.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)