### PR TITLE
Disable unused SDL loggers

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -190,12 +190,12 @@ local function updateSDLLogProperties()
         value = "%%-5p [%%d{yyyy-MM-dd HH:mm:ss,SSS}][%%t][%%c] %%F:%%L %%M: %%m"
       },
       {
-        name = "log4j.appender.TransportManagerLogFile.File",
-        value = "/dev/null"
+        name = "log4j.appender.TransportManagerLogFile",
+        value = "SafeFileAppender\nlog4j.appender.TransportManagerLogFile.Threshold=OFF"
       },
       {
-        name = "log4j.appender.ProtocolFordHandlingLogFile.File",
-        value = "/dev/null"
+        name = "log4j.appender.ProtocolFordHandlingLogFile",
+        value = "SafeFileAppender\nlog4j.appender.ProtocolFordHandlingLogFile.Threshold=OFF"
       }
     }
 

--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -187,7 +187,15 @@ local function updateSDLLogProperties()
       },
       {
         name = "log4j.appender.TelnetLogging.layout.ConversionPattern",
-        value = "%%-5p [%%d{yyyy-MM-dd HH-mm:ss,SSS}][%%t][%%c] %%F:%%L %%M: %%m"
+        value = "%%-5p [%%d{yyyy-MM-dd HH:mm:ss,SSS}][%%t][%%c] %%F:%%L %%M: %%m"
+      },
+      {
+        name = "log4j.appender.TransportManagerLogFile.File",
+        value = "/dev/null"
+      },
+      {
+        name = "log4j.appender.ProtocolFordHandlingLogFile.File",
+        value = "/dev/null"
       }
     }
 


### PR DESCRIPTION
Fix: #175

This PR is **ready** for review.

### Summary
Switch off `TransportManagerLog` and `ProtocolFordHandlingLog` SDL loggers

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)