### PR TITLE
Switch off remote connection by default

### DIFF
--- a/modules/configuration/base_config.lua
+++ b/modules/configuration/base_config.lua
@@ -30,7 +30,7 @@ config.pathToSDL = ""
 --- Define path to SDL .INI file
 config.pathToSDLConfig = ""
 --- Define path to SDL Policy database
-config.pathToSDLPolicyDB = ""
+config.pathToSDLPolicyDB = "policy.sqlite"
 --- Define path to SDL interfaces
 -- Example: "/home/user/sdl_panasonic/src/components/interfaces"
 config.pathToSDLInterfaces = ""

--- a/modules/configuration/connection_config.lua
+++ b/modules/configuration/connection_config.lua
@@ -10,7 +10,7 @@ local config = { }
 
 --- Remote cofiguration
 config.remoteConnection = {}
-config.remoteConnection.enabled = true
+config.remoteConnection.enabled = false
 --- Define host for default remote connection
 config.remoteConnection.url = "127.0.0.1"
 config.remoteConnection.port = 5555


### PR DESCRIPTION
Remote connection was set as default in https://github.com/smartdevicelink/sdl_atf/pull/180
We suppose local run is more preferable as default option for better compatibility.
In this way `--config` option can be omitted. 