### PR TITLE
move dependencies to smartdevicelink org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "modules/json4lua"]
     path = modules/json4lua
-    url = https://github.com/livio/json4lua
+    url = https://github.com/smartdevicelink/json4lua
     branch = master

--- a/src/remote_adapter/README.md
+++ b/src/remote_adapter/README.md
@@ -8,7 +8,7 @@
 ## Dependencies:
  - [CMake](https://cmake.org/download/) : Download and install any release version > 3.11
  - **GNU Make & C++ compiler** : Install with command `sudo apt-get install build-essential`
- - [rpclib](https://github.com/rpclib/rpclib) : Library for TCP communication.
+ - [rpclib](https://github.com/smartdevicelink/rpclib) : Library for TCP communication.
    *Note* : Installed automatically while running CMake.
 
  - **Lua library** : Install with command `sudo apt-get install liblua5.2-dev`

--- a/src/remote_adapter/remote_adapter_client/CMakeLists.txt
+++ b/src/remote_adapter/remote_adapter_client/CMakeLists.txt
@@ -16,7 +16,7 @@ set (CMAKE_INCLUDE_CURRENT_DIR ON)
 set (CMAKE_AUTOMOC ON)
 
 FetchContent_Declare(rpclib
-    GIT_REPOSITORY https://github.com/livio/rpclib.git
+    GIT_REPOSITORY https://github.com/smartdevicelink/rpclib.git
     GIT_TAG v2.2.2)
 
 FetchContent_GetProperties(rpclib)

--- a/src/remote_adapter/remote_adapter_server/CMakeLists.txt
+++ b/src/remote_adapter/remote_adapter_server/CMakeLists.txt
@@ -12,7 +12,7 @@ if(QNXNTO)
 endif()
 
 FetchContent_Declare(rpclib
-    GIT_REPOSITORY https://github.com/livio/rpclib.git
+    GIT_REPOSITORY https://github.com/smartdevicelink/rpclib.git
     GIT_TAG v2.2.2)
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
dependencies have been migrated to the smartdevicelink org, we now can update the refs in each project to point to our forks.