### PR TITLE
Fix clean up of SDL certificates

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -452,7 +452,8 @@ end
 function SDL.CRT.clean()
   local ext = ".crt"
   local crtPath = getPath(SDL.INI.get("CACertificatePath"))
-  getExecFunc()("cd " .. crtPath .. " && find . -type l -not -name 'lib*' -exec rm -f {} \\;")
+  getExecFunc()("cd " .. crtPath .. " && find . -type l -regextype egrep -regex '.\\/[a-z,0-9]{8}.[0-9]'"
+    .. " -exec rm -f {} \\;")
   getExecFunc()("cd " .. crtPath .. " && rm -rf *" .. ext)
 end
 


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Improve clean up of SDL certificates function.

### Changelog

##### Bug Fixes
 - Now clean function deletes only symlinks related to certificates.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)