### PR TITLE
Minor fixes and improvements in runner

### DIFF
--- a/atf_parallels/docker/entrypoint.sh
+++ b/atf_parallels/docker/entrypoint.sh
@@ -19,7 +19,7 @@ echo "export LANG=en_US.UTF-8" >> /home/developer/.profile
 mkdir /tmp/corefiles
 chown developer /tmp/corefiles
 chgrp developer /tmp/corefiles
-echo '/tmp/corefiles/core.%e.%p.%t' | sudo tee /proc/sys/kernel/core_pattern
+echo '/tmp/corefiles/core.%e.%p.%t' > /proc/sys/kernel/core_pattern
 
 cd /home/developer/sdl/atf
 sudo -E -u developer ./start.sh "$@"

--- a/atf_parallels/loop.sh
+++ b/atf_parallels/loop.sh
@@ -48,7 +48,7 @@ function pop {
         if [ -n "$LINE" ]; then
             sed -i '1d' $FILE
             RES=0
-            if [ -z $_test_id_file ]; then echo 0 > $_test_id_file; fi
+            if [ ! -f $_test_id_file ]; then echo 0 > $_test_id_file; fi
             local CURRENT_ID=$(cat $_test_id_file)
             let CURRENT_ID=CURRENT_ID+1
             echo $CURRENT_ID > $_test_id_file

--- a/start.sh
+++ b/start.sh
@@ -323,7 +323,7 @@ build_atf_options() {
 
 create_report_folder() {
   dbg "Func" "create_report_folder" "Enter"
-  REPORT_PATH_TS=${REPORT_PATH}/$(date +"%Y-%m-%d_%H-%M-%S")
+  REPORT_PATH_TS=${REPORT_PATH}/$(date +"%Y-%m-%d_%H-%M-%S.%3N")
   mkdir -p ${REPORT_PATH_TS}
   dbg "Func" "create_report_folder" "Exit"
 }

--- a/tools/runners/common.sh
+++ b/tools/runners/common.sh
@@ -166,7 +166,7 @@ copy_sdl_logs() {
   if [ $SAVE_SDL_LOG = true ] && [ -f $SDL_LOG ]; then
     cp $SDL_LOG ${REPORT_PATH_TS_SCRIPT}/
   fi
-  if [ $SAVE_SDL_CORE_DUMP = true ] && [ -d /tmp/corefiles ]; then
+  if [ $SAVE_SDL_CORE_DUMP = true ] && [ "$(ls -A /tmp/corefiles)" ]; then
     mv /tmp/corefiles/* ${REPORT_PATH_TS_SCRIPT}/
   fi
 }


### PR DESCRIPTION
This PR provides the following fixes and improvements for parallel mode:
- Extended test report folder by 'ms' suffix
Sometimes in parallel mode 2 scripts may run very fast and hence fall into the same 'timestamp' directory. This lead to a 'parse error' issue when total report is created. So adding of 'ms' suffix resolve the issue.
- Removed echoing of 'corefiles ...' string
- Removed echoing of string about missing SDL core files
- Removed echoing of '.test_id file not found' string