### PR TITLE
Do not send messages on HMI connection if it doesn't exist

### DIFF
--- a/modules/hmi_adapter/remote_hmi_adapter.lua
+++ b/modules/hmi_adapter/remote_hmi_adapter.lua
@@ -52,9 +52,10 @@ function RemoteHMIAdapter.mt.__index:Send(data)
   else
     text = data
   end
-
-  atf_logger.LOG("HMItoSDL", text)
-  self.connection:write(text)
+  if self.connection then
+    atf_logger.LOG("HMItoSDL", text)
+    self.connection:write(text)
+  end
 end
 
 --- Set handler for OnInputData


### PR DESCRIPTION
Currently a few tests may fail in Remote Connection mode:
```
./test_scripts/Smoke/API/037_RegisterAppInterface_PositiveCase_SUCCESS.lua
./test_scripts/Smoke/Registration/004_Reregister_App.lua
```
With an error:
```
Lua panic: ./modules/hmi_adapter/remote_hmi_adapter.lua:57: attempt to index field 'connection' (a nil value) (/home/developer/sdl/sdl_atf/src/remote_adapter/remote_adapter_client/lua_remote_library.cc:16)
```

This PR resolve an issue when ATF tries to send messages through non existing connection