### PR TITLE
Improve collecting of SDL logs and core dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,15 @@ E.g. if path to SDL binaries is defined through `--sdl-core` command line argume
   - test set
   - folder with test scripts
 - [OPTION] - is one or more of available options:
-  - --sdl-core &lt;path&gt; - path to SDL binaries
-  - --config &lt;folder&gt; - name of the folder with configuration
-  - --sdl-api &lt;path&gt;  - path to SDL APIs
-  - --report &lt;path&gt;   - path to report and logs
-  - --no-sdl-log            - force not to store SDL log
-  - --no-sdl-core-dump      - force not to store SDL core dump
-  - --parallels             - force to use local parallel mode
+  - --sdl-core &lt;path&gt;  - path to SDL binaries
+  - --config &lt;folder&gt;  - name of the folder with configuration
+  - --sdl-api &lt;path&gt;   - path to SDL APIs
+  - --report &lt;path&gt;    - path to report and logs
+  - --sdl-log [ACTION]       - how to collect SDL logs:
+    'yes' - (default) always save, 'no' - do not save, 'fail' - save if script failed or aborted
+  - --sdl-core-dump [ACTION] - how to collect SDL core dumps:
+    'yes' - (default) always save, 'no' - do not save, 'fail' - save if script failed or aborted
+  - --parallels              - force to use local parallel mode
     - -j|--jobs &lt;n&gt;        - number of simultaneous jobs to start
     - --third-party &lt;path&gt; - path to SDL third party
     - --tmp &lt;path&gt;         - path to temporary folder
@@ -216,7 +218,7 @@ The best approach is to use predefined configuration (e.g. `remote_linux`) as ba
 
 ### Advanced options
 
-1. For a big tests sets (>1000 scripts) Report and Logs can be very huge (>10Gb). Most of the space is occupied by SDL logs. In order to turn them off `--no-sdl-log` or `--no-sdl-core-dump` options can be specified.
+1. For a big tests sets (>1000 scripts) Report and Logs can be very huge (>10Gb). Most of the space is occupied by SDL logs. In order to turn them off `--sdl-log` or `--sdl-core-dump` options with `no` or `fail` value can be specified.
 2. Some scripts (old policy ones) create the same temporary files inside `files`, `test_scripts` or `user_modules` folders. In case of parallel mode the same temporary file can be used by different scripts at the same time. This leads to incorrect results or even aborts. In order to mitigate this issue `--copy-atf-ts` option can be specified. It tells ATF to copy mentioned folders for each job instead of creating symlinks.
 
 ## Documentation generation

--- a/atf_parallels/loop.sh
+++ b/atf_parallels/loop.sh
@@ -92,8 +92,8 @@ function main {
         local script_name=$(echo $row | awk '{print $2}')
 
         docker_run $script_name \
-          $([ "$_save_sdl_log" = false ] && echo "--no-sdl-log") \
-          $([ "$_save_sdl_core_dump" = false ] && echo "--no-sdl-core-dump") \
+          --sdl-log=$_save_sdl_log \
+          --sdl-core-dump=$_save_sdl_core_dump \
           --test-id $script_num
 
         sleep 0.1

--- a/tools/runners/common.sh
+++ b/tools/runners/common.sh
@@ -162,14 +162,18 @@ clean_sdl_folder() {
 }
 
 copy_sdl_logs() {
-  local SDL_LOG=$SDL_CORE/SmartDeviceLinkCore.log
-  if [ $SAVE_SDL_LOG = true ] && [ -f $SDL_LOG ]; then
-    cp $SDL_LOG ${REPORT_PATH_TS_SCRIPT}/
+  local is_script_failed=$(([ ${LIST_FAILED[ID]} ] || [ ${LIST_ABORTED[ID]} ]) && echo true || echo false)
+  if [ $SAVE_SDL_LOG = yes ] || ( [ $SAVE_SDL_LOG = fail ] && [ $is_script_failed == true ] ); then
+    local SDL_LOG=$SDL_CORE/SmartDeviceLinkCore.log
+    if [ -f $SDL_LOG ]; then
+      mv $SDL_LOG ${REPORT_PATH_TS_SCRIPT}/
+    fi
   fi
-  local SDL_CORE_PATH="/tmp/corefiles"
-  if [ $SAVE_SDL_CORE_DUMP = true ] && [ -d $SDL_CORE_PATH ] && [ "$(ls -A $SDL_CORE_PATH)" ];
-  then
-    mv $SDL_CORE_PATH/* ${REPORT_PATH_TS_SCRIPT}/
+  if [ $SAVE_SDL_CORE_DUMP = yes ] || ( [ $SAVE_SDL_CORE_DUMP = fail ] && [ $is_script_failed == true ] ); then
+    local SDL_CORE_PATH="/tmp/corefiles"
+    if [ -d $SDL_CORE_PATH ] && [ "$(ls -A $SDL_CORE_PATH)" ]; then
+      mv $SDL_CORE_PATH/* ${REPORT_PATH_TS_SCRIPT}/
+    fi
   fi
 }
 


### PR DESCRIPTION
This PR extends possible options how SDL logs and core dumps are collected.

Existing `--no-sdl-log` and `--no-sdl-core-dump` command line arguments are replaced by `--sdl-log` and `--sdl-core-dump` with the following possible values:
 - `yes` - always save (default)
 - `no` - do not save 
 - `fail` - save if script failed or aborted

Last option is most useful for full regression set runs, since it significantly reduce size of SDL logs, but still allows to have them for `FAILED` and `ABORTED` scripts.