### PR TITLE
Fix build warnings and parallels script for Ubuntu 20.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ git clone https://github.com/smartdevicelink/sdl_atf_test_scripts.git
 - Run the following commands:
 ```
 $ sudo apt-get install lua5.2 liblua5.2-dev libxml2-dev lua-lpeg-dev
-$ sudo apt-get install openssl libssl1.0-dev
+$ sudo apt-get install openssl libssl-dev net-tools
 ```
 
 **2.** Install Qt5.9+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ git clone https://github.com/smartdevicelink/sdl_atf_test_scripts.git
 ```
 
 ## Compilation
-**1.** Install 3d-parties developers libraries
+**1.** Install 3rd-parties developers libraries
 - Run the following commands:
 ```
 $ sudo apt-get install lua5.2 liblua5.2-dev libxml2-dev lua-lpeg-dev
@@ -37,7 +37,7 @@ $ sudo apt-get install openssl libssl1.0-dev
 ```
 
 **2.** Install Qt5.9+
-- For Ubuntu `18.04`:
+- For Ubuntu `18.04+`:
     - Run the following command:
 ```
 $ sudo apt-get install libqt5websockets5 libqt5websockets5-dev
@@ -83,7 +83,7 @@ $ ln -s ../../sdl_atf_test_scripts/user_modules
 **5.** Install dependencies for local parallel mode
 
 Steps below are required only in case if local parallel mode is going to be used.
-- Install Docker, e.g. [how-to](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-18-04)
+- Install Docker, e.g. [how-to](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-20-04)
 - Install additional tools:
 ```
 $ sudo apt-get install screen rsync
@@ -93,8 +93,8 @@ $ sudo apt-get install screen rsync
 $ cd atf_parallels/docker
 $ ./build.sh <ubuntu_version>
 ```
-<b>Note:</b> accepted values are `16` and `18` (will be processed as `16.04` and `18.04` correspondingly).
-If version is not specified `18` will be used by default.
+<b>Note:</b> accepted values are `16`, `18`, and `20` (will be processed as `16.04`, `18.04`, and `20.04` correspondingly).
+If version is not specified `20` will be used by default.
 
 ## Settings
 

--- a/atf_parallels/docker/Dockerfile
+++ b/atf_parallels/docker/Dockerfile
@@ -5,12 +5,14 @@ FROM ubuntu:${ubuntu_ver}
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 RUN apt-get update && apt-get -q -y install \
-  locales sudo libssl1.0.0 libssl-dev libusb-1.0-0 libbluetooth3 openssl liblua5.2-0 psmisc \
+  locales sudo libssl1.1 libssl-dev libusb-1.0-0 libbluetooth3 openssl liblua5.2-0 psmisc \
   libexpat1 sqlite3 libqt5websockets5 net-tools iproute2 \
-  libssl-doc- libusb-1.0-doc- autotools-dev- binutils- build-essential- bzip2- cpp- cpp-5- \
+  libssl-doc- libusb-1.0-doc- autotools-dev- binutils- build-essential- bzip2- cpp- \
   dpkg-dev- fakeroot- manpages- manpages-dev- qttranslations5-l10n- xdg-user-dirs- xml-core- dbus-
 
-RUN ln -s /lib/x86_64-linux-gnu/libexpat.so.1.6.7 /usr/lib/x86_64-linux-gnu/libexpat.so
+ARG expat_lib_ver
+
+RUN ln -s /lib/x86_64-linux-gnu/libexpat.so.${expat_lib_ver} /usr/lib/x86_64-linux-gnu/libexpat.so
 
 RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 

--- a/atf_parallels/docker/Dockerfile
+++ b/atf_parallels/docker/Dockerfile
@@ -4,8 +4,10 @@ FROM ubuntu:${ubuntu_ver}
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
+ARG openssl_lib_ver
+
 RUN apt-get update && apt-get -q -y install \
-  locales sudo libssl1.1 libssl-dev libusb-1.0-0 libbluetooth3 openssl liblua5.2-0 psmisc \
+  locales sudo libssl${openssl_lib_ver} libssl-dev libusb-1.0-0 libbluetooth3 openssl liblua5.2-0 psmisc \
   libexpat1 sqlite3 libqt5websockets5 net-tools iproute2 \
   libssl-doc- libusb-1.0-doc- autotools-dev- binutils- build-essential- bzip2- cpp- \
   dpkg-dev- fakeroot- manpages- manpages-dev- qttranslations5-l10n- xdg-user-dirs- xml-core- dbus-

--- a/atf_parallels/docker/build.sh
+++ b/atf_parallels/docker/build.sh
@@ -19,8 +19,6 @@ fi
 
 case $_ubuntu_ver in
   16|18|20)
-    _ubuntu_ver=$_ubuntu_ver.04
-
     case $_ubuntu_ver in
       16)
         _openssl_lib_ver=1.0.0
@@ -30,6 +28,8 @@ case $_ubuntu_ver in
       *)
         ;;
     esac
+
+    _ubuntu_ver=$_ubuntu_ver.04
 
     if [ ! -z $_hosted_ubuntu_ver ]; then
       if [ ! $_hosted_ubuntu_ver = $_ubuntu_ver ]; then

--- a/atf_parallels/docker/build.sh
+++ b/atf_parallels/docker/build.sh
@@ -3,6 +3,7 @@
 _ubuntu_ver=$1
 _ubuntu_ver_default=20
 _hosted_ubuntu_ver=$(lsb_release -sr 2>/dev/null)
+_openssl_lib_ver=1.1
 _expat_lib_ver=1.6.11
 
 function warning {
@@ -22,7 +23,8 @@ case $_ubuntu_ver in
 
     case $_ubuntu_ver in
       16)
-        _expat_lib_ver=1.6.7;;
+        _openssl_lib_ver=1.0.0
+        _expat_lib_ver=1.6.0;;
       18)
         _expat_lib_ver=1.6.7;;
       *)
@@ -43,4 +45,4 @@ case $_ubuntu_ver in
     exit 1;;
 esac
 
-docker build --build-arg ubuntu_ver=$_ubuntu_ver --build-arg expat_lib_ver=$_expat_lib_ver -f Dockerfile -t atf_worker .
+docker build --build-arg ubuntu_ver=$_ubuntu_ver --build-arg openssl_lib_ver=$_openssl_lib_ver --build-arg expat_lib_ver=$_expat_lib_ver -f Dockerfile -t atf_worker .

--- a/atf_parallels/docker/build.sh
+++ b/atf_parallels/docker/build.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 _ubuntu_ver=$1
-_ubuntu_ver_default=18
+_ubuntu_ver_default=20
 _hosted_ubuntu_ver=$(lsb_release -sr 2>/dev/null)
+_expat_lib_ver=1.6.11
 
 function warning {
   echo "--WARNING!"
@@ -16,8 +17,18 @@ if [ -z $_ubuntu_ver ]; then
 fi
 
 case $_ubuntu_ver in
-  16|18)
+  16|18|20)
     _ubuntu_ver=$_ubuntu_ver.04
+
+    case $_ubuntu_ver in
+      16)
+        _expat_lib_ver=1.6.7;;
+      18)
+        _expat_lib_ver=1.6.7;;
+      *)
+        ;;
+    esac
+
     if [ ! -z $_hosted_ubuntu_ver ]; then
       if [ ! $_hosted_ubuntu_ver = $_ubuntu_ver ]; then
         warning "Specified Ubuntu version '$_ubuntu_ver' does not match the hosted Ubuntu version '$_hosted_ubuntu_ver'"
@@ -28,8 +39,8 @@ case $_ubuntu_ver in
 
     echo "Ubuntu version: "$_ubuntu_ver;;
   *)
-    warning "Specified Ubuntu version '$_ubuntu_ver' is unexpected. Allowed versions: 16 or 18";
+    warning "Specified Ubuntu version '$_ubuntu_ver' is unexpected. Allowed versions: 16, 18, or 20";
     exit 1;;
 esac
 
-docker build --build-arg ubuntu_ver=$_ubuntu_ver -f Dockerfile -t atf_worker .
+docker build --build-arg ubuntu_ver=$_ubuntu_ver --build-arg expat_lib_ver=$_expat_lib_ver -f Dockerfile -t atf_worker .

--- a/src/remote_adapter/remote_adapter_server/plugins/transport/message_broker.cpp
+++ b/src/remote_adapter/remote_adapter_server/plugins/transport/message_broker.cpp
@@ -570,7 +570,7 @@ MessageBroker<TCPListener>::MakeEndpoint(const std::string &address,
 
   auto const ip_address = boost::asio::ip::make_address(address.c_str());
 
-  return tcp::endpoint{ip_address, port};
+  return tcp::endpoint{ip_address, static_cast<unsigned short>(port)};
 }
 
 #define LIBRARY_API extern "C"


### PR DESCRIPTION
Partially implements #219 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test build on Ubuntu 20.04

### Summary
Adds support for Ubuntu 20.04, fixing build errors and warnings with the project

### Changelog
##### Enhancements
* Updates docker build scripts to support Ubuntu 20.04

##### Bug Fixes
* Fixes warnings in project when building with gcc9

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
