### PR TITLE
Update boost version

### DIFF
--- a/src/remote_adapter/remote_adapter_server/BOOST.cmake
+++ b/src/remote_adapter/remote_adapter_server/BOOST.cmake
@@ -24,10 +24,14 @@ if(QNXNTO)
     set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH}" "${BOOST_ROOT}")
 endif()
 
-find_package(Boost 1.68.0 COMPONENTS system filesystem)
+find_package(Boost 1.72.0 COMPONENTS system filesystem)
 
 if (NOT ${Boost_FOUND})
-    message(STATUS "Did not find boost. Downloading and installing boost 1.68")
+    message(STATUS "Did not find boost. Downloading and installing boost 1.72")
+    set(BOOST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/third_party/boost)
+    set(BOOST_INSTALL ${BOOST_ROOT})
+    set(BOOST_INCLUDE_DIRS ${BOOST_INSTALL}/include)
+    set(BOOST_LIBRARY_DIRS ${BOOST_INSTALL}/lib)
     if(NOT QNXNTO)
         set(BOOST_GCC_JAM "")
         set(BOOST_FILESYSTEM_OPERATION "")
@@ -59,7 +63,7 @@ if (NOT ${Boost_FOUND})
     endif()
     set(BOOST_INSTALL_COMMAND ${BOOST_BUILD_COMMAND} install)
     ExternalProject_Add(Boost
-        URL https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz https://newcontinuum.dl.sourceforge.net/project/boost/boost/1.68.0/boost_1_68_0.tar.gz
+        URL https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz https://newcontinuum.dl.sourceforge.net/project/boost/boost/1.72.0/boost_1_72_0.tar.gz
         DOWNLOAD_DIR ${BOOST_LIB_SOURCE_DIRECTORY}
         SOURCE_DIR ${BOOST_LIB_SOURCE_DIRECTORY}
         CONFIGURE_COMMAND  ${BOOST_GCC_JAM} COMMAND ${BOOST_FILESYSTEM_OPERATION} COMMAND ${BOOTSTRAP}
@@ -67,6 +71,9 @@ if (NOT ${Boost_FOUND})
         INSTALL_COMMAND ${BOOST_INSTALL_COMMAND}
         INSTALL_DIR ${BOOST_INSTALL}
         BUILD_IN_SOURCE true)
+else()
+    set(BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
+    set(BOOST_LIBRARY_DIRS ${Boost_LIBRARY_DIRS})
 endif()
 
 set(BOOST_LIBRARIES

--- a/src/remote_adapter/remote_adapter_server/plugins/transport/message_broker.h
+++ b/src/remote_adapter/remote_adapter_server/plugins/transport/message_broker.h
@@ -4,7 +4,6 @@
 #include "rpc/detail/log.h"
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <future>
@@ -126,7 +125,6 @@ private:
   void OnClose(boost::system::error_code ec);
 
   websocket::stream<tcp::socket> ws_;
-  boost::asio::strand<boost::asio::io_context::executor_type> strand_;
   boost::beast::multi_buffer read_buffer_;
   std::queue<std::string> msg_queue_;
   std::mutex msg_queue_lock_;


### PR DESCRIPTION
Boost changes to correspond with https://github.com/smartdevicelink/sdl_core/pull/3651

Updates Boost library usage to work with boost 1.72.0, also fixes CMake issue with detecting an existing version of the Boost library