### PR TITLE
Adjust lookup logic for SDL libraries

### DIFF
--- a/tools/runners/parallels.sh
+++ b/tools/runners/parallels.sh
@@ -63,8 +63,8 @@ function prepare_sdl {
   fi
   LD_LIBRARY_PATH="$llp" \
     ldd $_sdl_prepared/bin/smartDeviceLinkCore \
-    | grep "$fltr" \
     | awk '{print $3}' \
+    | grep "$fltr" \
     | xargs -L1 -I LIB cp LIB $_sdl_prepared/bin
 }
 
@@ -292,7 +292,7 @@ function process_report {
   elif [[ $skipped_tests == 1 ]]; then
     echo -e "$dir_number:\tSKIPPED\t$test_target" >> $tmp_report_file
   elif [[ $missing_tests == 1 ]]; then
-    echo -e "$dir_number:\tMISSING\t$test_target" >> $tmp_report_file    
+    echo -e "$dir_number:\tMISSING\t$test_target" >> $tmp_report_file
   else
     echo -e "$dir_number:\tPARSING ERROR\t$test_target" >> $tmp_report_file
     return 1


### PR DESCRIPTION
This PR address an issue when ATF in parallel mode shows odd messages:
```
cp: cannot stat 'version': No such file or directory
```
Issue is happen in case if host OS where ATF is running is differ from the OS of SDL build.
E.g.:
SDL is built on Ubuntu 20. Docker image `atf_worker` is also built for Ubuntu 20.
However ATF is going to be started at Ubuntu 18.

Change in this PR modifies look up logic of SDL libraries: at first ATF tries to find all required libraries with full path for each file and only then filter these libraries by defined pattern. 