### PR TITLE
Add handling for AppIcons folder

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -541,6 +541,16 @@ function SDL.AppStorage.clean(pPath)
   getExecFunc()("rm -rf " .. SDL.AppStorage.path() .. pPath)
 end
 
+SDL.AppIcons = {}
+
+function SDL.AppIcons.path()
+  return getPath(SDL.INI.get("AppIconsFolder"))
+end
+
+function SDL.AppIcons.clean()
+  getExecFunc()("rm -rf " .. SDL.AppIcons.path())
+end
+
 SDL.AppInfo = {}
 
 function SDL.AppInfo.file()

--- a/tools/runners/common.sh
+++ b/tools/runners/common.sh
@@ -5,7 +5,7 @@ SDL_BACK_UP=("sdl_preloaded_pt.json" "smartDeviceLink.ini" "hmi_capabilities.jso
 
 # ATF and SDL files/folders to remove before each script run
 ATF_CLEAN_UP=("sdl.pid" "mobile*.out")
-SDL_CLEAN_UP=("*.log" "app_info.dat" "storage" "ivsu_cache" "../sdl_bin_bk")
+SDL_CLEAN_UP=("*.log" "app_info.dat" "storage" "icons" "ivsu_cache" "../sdl_bin_bk")
 
 logf() { log "$@" | tee -a ${REPORT_PATH_TS}/${REPORT_FILE}; }
 
@@ -106,7 +106,7 @@ run_atf() {
     5)
       RESULT_STATUS="MISSING"
       LIST_MISSING[ID]="$ID_SFX|$SCRIPT|$ISSUE"
-    ;;    
+    ;;
   esac
 
   local total="$ID_SFX:\t$RESULT_STATUS\t$SCRIPT"


### PR DESCRIPTION
Within https://github.com/smartdevicelink/sdl_core/pull/2202 folder for icons had changed from `storage` to a `icons`
Current PR adds support for `AppIconsFolder` SDL .INI parameter and clean up logic in `common` runner