### PR TITLE
Add creation of sub-folders for AppInfo and HMICapCache

### DIFF
--- a/modules/SDL.lua
+++ b/modules/SDL.lua
@@ -565,7 +565,7 @@ end
 
 function SDL.AppInfo.set(pAppInfo)
   local content = json.encode(pAppInfo)
-  getExecFunc()("mkdir " .. SDL.AppStorage.path())
+  getExecFunc()("mkdir -p " .. SDL.AppStorage.path())
   saveFileContent(SDL.AppInfo.file(), content)
 end
 
@@ -594,7 +594,7 @@ end
 
 function SDL.HMICapCache.set(pHmiCapCache)
   local content = json.encode(pHmiCapCache)
-  getExecFunc()("mkdir " .. SDL.AppStorage.path())
+  getExecFunc()("mkdir -p " .. SDL.AppStorage.path())
   saveFileContent(SDL.HMICapCache.file(), content)
 end
 


### PR DESCRIPTION
Currently there is an error message 
```
mkdir: cannot create directory ‘/home/developer/sdl/bin/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu/’: No such file or directory
```
when running scripts:
```
./test_scripts/API/RemoveUrlParameterMaxLength/002_StartStream.lua
./test_scripts/API/RemoveUrlParameterMaxLength/003_StartAudioStream.lua
```

Additionally these scripts failed for `WS` and `WSS` connection for `EXTERNAL_PROPRIETARY` SDL policy mode:
```
[02:58:42,613] RAI                                                                                   [FAIL] (11338 ms)
 PTU start event: Timeout: PTU start event: Timeout expired
 OnSystemRequest notification: Timeout: OnSystemRequest notification: Timeout expired
 HMI call BasicCommunication.PolicyUpdate: Timeout: HMI call BasicCommunication.PolicyUpdate: Timeout expired
[02:58:53,951] Activate_App                                                                          [FAIL] (11203 ms)
 OnHMIStatus notification: Timeout: OnHMIStatus notification: Timeout expired
```

Fix is to add `-p` option for `mkdir` which allows creating of sub-folders tree.