### PR TITLE
Update boost download url

### DIFF
--- a/src/remote_adapter/remote_adapter_server/BOOST.cmake
+++ b/src/remote_adapter/remote_adapter_server/BOOST.cmake
@@ -63,7 +63,7 @@ if (NOT ${Boost_FOUND})
     endif()
     set(BOOST_INSTALL_COMMAND ${BOOST_BUILD_COMMAND} install)
     ExternalProject_Add(Boost
-        URL https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz https://newcontinuum.dl.sourceforge.net/project/boost/boost/1.72.0/boost_1_72_0.tar.gz
+        URL https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.gz/download https://newcontinuum.dl.sourceforge.net/project/boost/boost/1.72.0/boost_1_72_0.tar.gz
         DOWNLOAD_DIR ${BOOST_LIB_SOURCE_DIRECTORY}
         SOURCE_DIR ${BOOST_LIB_SOURCE_DIRECTORY}
         CONFIGURE_COMMAND  ${BOOST_GCC_JAM} COMMAND ${BOOST_FILESYSTEM_OPERATION} COMMAND ${BOOTSTRAP}


### PR DESCRIPTION
Update boost download url to use sourceforge

Fixes #229 