### PR TITLE
Increase default timeout

### DIFF
--- a/modules/expectations.lua
+++ b/modules/expectations.lua
@@ -163,7 +163,7 @@ function Expectations.Expectation(name, connection)
     timesGE = 1, -- Times Greater or Equal
     after = { }, -- Expectations that should get complied before this one
     ts = timestamp(), -- Timestamp
-    timeout = 10500, -- Maximum allowed age
+    timeout = 11500, -- Maximum allowed age
     name = name, -- Name to display in error message if failed
     connection = connection, -- Network connection
     occurences = 0, -- Expectation complience times


### PR DESCRIPTION
This PR address the https://github.com/smartdevicelink/sdl_core/pull/3726#issuecomment-888553791 comment
It increases default timeout for the responses from SDL
Corresponding PR in Core: `<TBA>`
Corresponding PR in Scripts: https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2562 (commits: [dad3dff](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2562/commits/dad3dff73fc5526a21512f880dbc0557ac144ea0) and [bc42534](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2562/commits/bc42534e0a813473026ec5cb487e34e786573755))