### PR TITLE
Remove query type from SendHandshakeData event matcher

### DIFF
--- a/modules/atf_logger.lua
+++ b/modules/atf_logger.lua
@@ -61,7 +61,6 @@ local function get_function_name(message)
 
   if message.frameType ~= ford_constants.FRAME_TYPE.CONTROL_FRAME then
     if message.serviceType == ford_constants.SERVICE_TYPE.CONTROL
-        and message.rpcType == ford_constants.BINARY_RPC_TYPE.NOTIFICATION
         and message.rpcFunctionId == ford_constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE then
       return "SSL: Handshake"
     end

--- a/modules/services/control_service.lua
+++ b/modules/services/control_service.lua
@@ -33,7 +33,6 @@ local function performStartServiceHandshake(controlService)
         return data.frameType ~= constants.FRAME_TYPE.CONTROL_FRAME
           and data.serviceType == constants.SERVICE_TYPE.CONTROL
           and data.sessionId == controlService.session.sessionId.get()
-          and data.rpcType == constants.BINARY_RPC_TYPE.NOTIFICATION
           and data.rpcFunctionId == constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE
       end
 
@@ -46,7 +45,7 @@ local function performStartServiceHandshake(controlService)
             frameInfo = 0,
             serviceType = constants.SERVICE_TYPE.CONTROL,
             encryption = false,
-            rpcType = constants.BINARY_RPC_TYPE.NOTIFICATION,
+            rpcType = constants.BINARY_RPC_TYPE.RESPONSE,
             rpcFunctionId = constants.BINARY_RPC_FUNCTION_ID.HANDSHAKE,
             rpcCorrelationId = data.rpcCorrelationId,
             binaryData = dataToSend


### PR DESCRIPTION
ATF changes for https://github.com/smartdevicelink/sdl_core/issues/3755

- Removes query type from SendHandshakeData event matcher
- Uses RESPONSE query type in SendHandshakeData response