### PR TITLE
Updates for [SDL-0125] ATF streaming data validation

### DIFF
--- a/modules/hmi_adapter/hmi_stream_adapter_controller.lua
+++ b/modules/hmi_adapter/hmi_stream_adapter_controller.lua
@@ -32,7 +32,7 @@ function Stream.TcpConnection(host, port, bytes, func)
   res.socket = network.TcpClient()
   res.qtproxy = qt.dynamic()
 
-  function streamTcpCleanup()
+  local function streamTcpCleanup()
     local file = io.open("tcp_stream.out","w+b")
     local streamedData = table.concat(res.data)
     file:write(streamedData)

--- a/modules/hmi_adapter/hmi_stream_adapter_controller.lua
+++ b/modules/hmi_adapter/hmi_stream_adapter_controller.lua
@@ -2,8 +2,8 @@
 --
 -- *Dependencies:* `qt`, `network`
 --
--- *Globals:* `xmlReporter`, `qt`, `network`
--- @module tcp_connection
+-- *Globals:* `qt`, `network`
+-- @module Stream
 -- @copyright [SmartDeviceLink Consortium](https://smartdevicelink.com/consortium/)
 -- @license <https://github.com/smartdevicelink/sdl_core/blob/master/LICENSE>
 
@@ -14,7 +14,7 @@ local Stream = { }
 
 --- Construct instance of Connection type
 -- @tparam string host SDL host address
--- @tparam string port SDL port
+-- @tparam number port SDL port
 -- @tparam number bytes Number of bytes to receive before calling callback
 -- @tparam function func Callback when stream ends or number of bytes are received
 -- @treturn Connection Constructed instance
@@ -44,7 +44,7 @@ function Stream.TcpConnection(host, port, bytes, func)
     res.data[tableIndex+1] = data
 
     if tableIndex == 0 then
-        -- trim off TCP header
+        -- trim off HTTP header
         local headerEnd = data:find("\r\n\r\n")
         res.data[tableIndex+1] = string.sub(data, headerEnd + 4)
     end
@@ -73,7 +73,7 @@ function Stream.TcpConnection(host, port, bytes, func)
       res.callback(false, res.receivedBytes, "tcp_video.out")
     end
   end
-  
+
   qt.connect(res.socket, "disconnected()", res.qtproxy, "disconnected()")
 
   res.qtproxy.connected = function() print("HMI connected to stream") end

--- a/modules/hmi_adapter/hmi_stream_adapter_controller.lua
+++ b/modules/hmi_adapter/hmi_stream_adapter_controller.lua
@@ -39,7 +39,7 @@ function Stream.TcpConnection(host, port, bytes, func)
     file:close()
   end
 
-  function res.qtproxy.inputData(_, data)
+  local function processInputData(data)
     local tableIndex = #res.data
 
     if tableIndex == 0 then
@@ -63,7 +63,7 @@ function Stream.TcpConnection(host, port, bytes, func)
     while true do
       local data = res.socket:read(81920)
       if data == '' or type(data) ~= "string" then break end
-      res.qtproxy:inputData(data)
+      processInputData(data)
     end
   end
 

--- a/modules/hmi_adapter/hmi_stream_adapter_controller.lua
+++ b/modules/hmi_adapter/hmi_stream_adapter_controller.lua
@@ -70,7 +70,7 @@ function Stream.TcpConnection(host, port, bytes, func)
   res.qtproxy.disconnected = function()
     if res.receivedBytes < res.callbackBytes then
       streamTcpCleanup()
-      res.callback(false, res.receivedBytes, "tcp_video.out")
+      res.callback(false, res.receivedBytes, "tcp_stream.out")
     end
   end
 

--- a/modules/hmi_adapter/hmi_stream_adapter_controller.lua
+++ b/modules/hmi_adapter/hmi_stream_adapter_controller.lua
@@ -41,14 +41,14 @@ function Stream.TcpConnection(host, port, bytes, func)
 
   function res.qtproxy.inputData(_, data)
     local tableIndex = #res.data
-    res.data[tableIndex+1] = data
 
     if tableIndex == 0 then
         -- trim off HTTP header
         local headerEnd = data:find("\r\n\r\n")
-        res.data[tableIndex+1] = string.sub(data, headerEnd + 4)
+        data = string.sub(data, headerEnd + 4)
     end
 
+    table.insert(res.data, data);
     local data_len = #data
     res.receivedBytes = res.receivedBytes + data_len
 


### PR DESCRIPTION
It is proposed some updates and improvements in original implementation of [[SDL 0125] ATF Video streaming support](https://github.com/smartdevicelink/sdl_atf/issues/118) feature.

Changes:
 - Updated description of hmi_stream_adapter module
 - Made streamTcpCleanup function local of hmi_stream_adapter module
 - Corrected counting of received bytes in Stream.TcpConnection
 - Corrected filename in handler of disconnect event in Stream.TcpConnection
 - Aligned Stream.TcpConnection according coding style
 - Remove redundant extending of QT object by Lua function in Stream.TcpConnection
 - Add support of testing of pipe streaming via remote connection