### PR TITLE
Add possibility to automatically create back-traces from core dump files

### DIFF
--- a/atf_parallels/docker/Dockerfile
+++ b/atf_parallels/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG openssl_lib_ver
 
 RUN apt-get update && apt-get -q -y install \
   locales sudo libssl${openssl_lib_ver} libssl-dev libusb-1.0-0 libbluetooth3 openssl liblua5.2-0 psmisc \
-  libexpat1 sqlite3 libqt5websockets5 net-tools iproute2 \
+  libexpat1 sqlite3 libqt5websockets5 net-tools iproute2 gdb \
   libssl-doc- libusb-1.0-doc- autotools-dev- binutils- build-essential- bzip2- cpp- \
   dpkg-dev- fakeroot- manpages- manpages-dev- qttranslations5-l10n- xdg-user-dirs- xml-core- dbus-
 

--- a/atf_parallels/docker/entrypoint.sh
+++ b/atf_parallels/docker/entrypoint.sh
@@ -19,7 +19,7 @@ echo "export LANG=en_US.UTF-8" >> /home/developer/.profile
 mkdir /tmp/corefiles
 chown developer /tmp/corefiles
 chgrp developer /tmp/corefiles
-echo '/tmp/corefiles/core.%e.%p.%t' > /proc/sys/kernel/core_pattern
+echo '/tmp/corefiles/core.sdl.%p.%t' > /proc/sys/kernel/core_pattern
 
 cd /home/developer/sdl/atf
 sudo -E -u developer ./start.sh "$@"

--- a/start.sh
+++ b/start.sh
@@ -335,6 +335,7 @@ create_report_folder() {
   dbg "Func" "create_report_folder" "Enter"
   REPORT_PATH_TS=${REPORT_PATH}/$(date +"%Y-%m-%d_%H-%M-%S.%3N")
   mkdir -p ${REPORT_PATH_TS}
+  mkdir -p /tmp/corefiles
   dbg "Func" "create_report_folder" "Exit"
 }
 


### PR DESCRIPTION
Currently ATF collects core dump files in case if SDL Core aborted for some reason.
These core dump files are just intermediate artifacts. The main goal is to have back-traces created from them.
Currently this additional process has to be done manually.
It would be much useful to have back-traces created automatically along with other existing logs and report files.

This PR adds such possibility.